### PR TITLE
Add Transform struct and toDictionary transformation

### DIFF
--- a/Mapper.xcodeproj/project.pbxproj
+++ b/Mapper.xcodeproj/project.pbxproj
@@ -15,6 +15,9 @@
 		C233A2091BD98A870078125F /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = C233A2081BD98A870078125F /* Errors.swift */; };
 		C233A2571BD990140078125F /* Convertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = C233A2561BD990140078125F /* Convertible.swift */; };
 		C233A25A1BD9903F0078125F /* NSURL+Convertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = C233A2591BD9903F0078125F /* NSURL+Convertible.swift */; };
+		C2569A131BF3E87100A7CF10 /* Transform.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2569A121BF3E87100A7CF10 /* Transform.swift */; };
+		C2569A151BF3E88400A7CF10 /* Transform+Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2569A141BF3E88400A7CF10 /* Transform+Dictionary.swift */; };
+		C2569A171BF3E8AB00A7CF10 /* TransformTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2569A161BF3E8AB00A7CF10 /* TransformTests.swift */; };
 		C266A0CE1BD81901002A641F /* NormalValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C266A0CD1BD81901002A641F /* NormalValueTests.swift */; };
 		C266A0D01BD81908002A641F /* OptionalValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C266A0CF1BD81908002A641F /* OptionalValueTests.swift */; };
 		C266A0D21BD8190F002A641F /* MappableValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C266A0D11BD8190F002A641F /* MappableValueTests.swift */; };
@@ -45,6 +48,9 @@
 		C233A2081BD98A870078125F /* Errors.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
 		C233A2561BD990140078125F /* Convertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Convertible.swift; sourceTree = "<group>"; };
 		C233A2591BD9903F0078125F /* NSURL+Convertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSURL+Convertible.swift"; sourceTree = "<group>"; };
+		C2569A121BF3E87100A7CF10 /* Transform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Transform.swift; sourceTree = "<group>"; };
+		C2569A141BF3E88400A7CF10 /* Transform+Dictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Transform+Dictionary.swift"; sourceTree = "<group>"; };
+		C2569A161BF3E8AB00A7CF10 /* TransformTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransformTests.swift; sourceTree = "<group>"; };
 		C266A0CD1BD81901002A641F /* NormalValueTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NormalValueTests.swift; sourceTree = "<group>"; };
 		C266A0CF1BD81908002A641F /* OptionalValueTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OptionalValueTests.swift; sourceTree = "<group>"; };
 		C266A0D11BD8190F002A641F /* MappableValueTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MappableValueTests.swift; sourceTree = "<group>"; };
@@ -98,6 +104,7 @@
 				C233A2561BD990140078125F /* Convertible.swift */,
 				C233A2081BD98A870078125F /* Errors.swift */,
 				C201749F1BD550F900E4FE18 /* Mappable.swift */,
+				C2569A111BF3E86500A7CF10 /* Transformations */,
 				C201749D1BD550C200E4FE18 /* Mapper.swift */,
 			);
 			path = Mapper;
@@ -106,14 +113,15 @@
 		C20174911BD5509D00E4FE18 /* MapperTests */ = {
 			isa = PBXGroup;
 			children = (
-				C266A0D91BD81AA0002A641F /* Resources */,
 				C266A0D31BD81917002A641F /* ConvertibleValueTests.swift */,
 				C266A0D71BD81A62002A641F /* CustomTransformationTests.swift */,
-				C266A0D11BD8190F002A641F /* MappableValueTests.swift */,
 				C21A55D01BE7F1D6006B12E8 /* InitializerTests.swift */,
+				C266A0D11BD8190F002A641F /* MappableValueTests.swift */,
 				C266A0CD1BD81901002A641F /* NormalValueTests.swift */,
 				C266A0CF1BD81908002A641F /* OptionalValueTests.swift */,
 				C266A0D51BD81928002A641F /* RawRepresentibleValueTests.swift */,
+				C2569A161BF3E8AB00A7CF10 /* TransformTests.swift */,
+				C266A0D91BD81AA0002A641F /* Resources */,
 			);
 			path = MapperTests;
 			sourceTree = "<group>";
@@ -124,6 +132,15 @@
 				C233A2591BD9903F0078125F /* NSURL+Convertible.swift */,
 			);
 			path = Convertibles;
+			sourceTree = "<group>";
+		};
+		C2569A111BF3E86500A7CF10 /* Transformations */ = {
+			isa = PBXGroup;
+			children = (
+				C2569A121BF3E87100A7CF10 /* Transform.swift */,
+				C2569A141BF3E88400A7CF10 /* Transform+Dictionary.swift */,
+			);
+			name = Transformations;
 			sourceTree = "<group>";
 		};
 		C266A0D91BD81AA0002A641F /* Resources */ = {
@@ -253,8 +270,10 @@
 			files = (
 				C233A25A1BD9903F0078125F /* NSURL+Convertible.swift in Sources */,
 				C201749E1BD550C200E4FE18 /* Mapper.swift in Sources */,
+				C2569A151BF3E88400A7CF10 /* Transform+Dictionary.swift in Sources */,
 				C233A2571BD990140078125F /* Convertible.swift in Sources */,
 				C233A2091BD98A870078125F /* Errors.swift in Sources */,
+				C2569A131BF3E87100A7CF10 /* Transform.swift in Sources */,
 				C20174A01BD550F900E4FE18 /* Mappable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -269,6 +288,7 @@
 				C266A0D21BD8190F002A641F /* MappableValueTests.swift in Sources */,
 				C21A55D11BE7F1D6006B12E8 /* InitializerTests.swift in Sources */,
 				C266A0D41BD81917002A641F /* ConvertibleValueTests.swift in Sources */,
+				C2569A171BF3E8AB00A7CF10 /* TransformTests.swift in Sources */,
 				C266A0D81BD81A62002A641F /* CustomTransformationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Mapper/Transform+Dictionary.swift
+++ b/Mapper/Transform+Dictionary.swift
@@ -1,0 +1,17 @@
+public extension Transform {
+    public static func toDictionary<T, U where T: Mappable, U: Hashable>(key getKey: T -> U)
+        (object: AnyObject?) throws -> [U: T]
+    {
+        guard let objects = object as? [NSDictionary] else {
+            throw MapperError()
+        }
+
+        var dictionary: [U: T] = [:]
+        for object in objects {
+            let model = try T(map: Mapper(JSON: object))
+            dictionary[getKey(model)] = model
+        }
+
+        return dictionary
+    }
+}

--- a/Mapper/Transform.swift
+++ b/Mapper/Transform.swift
@@ -1,0 +1,1 @@
+public struct Transform {}

--- a/MapperTests/TransformTests.swift
+++ b/MapperTests/TransformTests.swift
@@ -1,0 +1,94 @@
+import Mapper
+import XCTest
+
+private struct Example: Mappable, Equatable {
+    let key: String
+    let value: Int
+
+    init(key: String, value: Int) {
+        self.key = key
+        self.value = value
+    }
+    
+    init(map: Mapper) throws {
+        try key = map.from("string")
+        try value = map.from("value")
+    }
+}
+
+private func ==(lhs: Example, rhs: Example) -> Bool {
+    return lhs.key == rhs.key && lhs.value == rhs.value
+}
+
+final class TransformTests: XCTestCase {
+    func testToDictionary() {
+        struct Test: Mappable {
+            let dictionary: [String: Example]
+
+            init(map: Mapper) throws {
+                try dictionary = map.from("examples",
+                    transformation: Transform.toDictionary(key: { $0.key }))
+            }
+        }
+
+        let JSON = [
+            "examples":
+            [
+                [
+                    "string": "hi",
+                    "value": 1,
+                ],
+                [
+                    "string": "bye",
+                    "value": 2,
+                ],
+            ]
+        ]
+        let test = Test.from(JSON)!
+
+        XCTAssertTrue(test.dictionary.count == 2)
+        XCTAssertTrue(test.dictionary["hi"] == Example(key: "hi", value: 1))
+        XCTAssertTrue(test.dictionary["bye"] == Example(key: "bye", value: 2))
+    }
+
+    func testToDictionaryInvalid() {
+        struct Test: Mappable {
+            let dictionary: [String: Example]
+
+            init(map: Mapper) throws {
+                try dictionary = map.from("examples",
+                    transformation: Transform.toDictionary(key: { $0.key }))
+            }
+        }
+
+        let test = try? Test(map: Mapper(JSON: [:]))
+        XCTAssertNil(test)
+    }
+
+    func testToDictionaryOneInvalid() {
+        struct Test: Mappable {
+            let dictionary: [String: Example]
+
+            init(map: Mapper) throws {
+                try dictionary = map.from("examples",
+                    transformation: Transform.toDictionary(key: { $0.key }))
+            }
+        }
+
+        let JSON = [
+            "examples":
+            [
+                [
+                    "string": "hi",
+                    "value": 1,
+                ],
+                [
+                    "string": "bye",
+                ]
+            ]
+        ]
+
+        let test = try? Test(map: Mapper(JSON: JSON))
+        XCTAssertNil(test)
+    }
+}


### PR DESCRIPTION
This is a struct that servers as a place for users to extend so
transformations don't all live in the global scope. This also adds a
single `toDictionary` transformation that will prove useful for us and
hopefully others.
