### PR TITLE
Add optionalFrom for an array of fields

### DIFF
--- a/Mapper/Mapper.swift
+++ b/Mapper/Mapper.swift
@@ -48,6 +48,24 @@ public struct Mapper {
         return try? self.from(field)
     }
 
+    /**
+     Get an optional value from the given keys and source data. This returns the first non-nil value produced
+     in order based on the array of fields
+
+     - parameter fields: The array of fields to check from the source data.
+
+     - returns: The first non-nil value to be produced from the array of fields, or nil if none exist
+    */
+    public func optionalFrom<T>(fields: [String]) -> T? {
+        for field in fields {
+            if let value: T = try? self.from(field) {
+                return value
+            }
+        }
+
+        return nil
+    }
+
     // MARK: - T: RawRepresentable
 
     /**

--- a/MapperTests/OptionalValueTests.swift
+++ b/MapperTests/OptionalValueTests.swift
@@ -49,4 +49,51 @@ final class OptionalValueTests: XCTestCase {
         let test = try! Test(map: Mapper(JSON: ["strings": ["first", "second"]]))
         XCTAssertTrue(test.strings!.count == 2)
     }
+
+    func testMappingArrayOfOptionalFieldsPicksNonNil() {
+        struct Test: Mappable {
+            let string: String?
+            init(map: Mapper) throws {
+                self.string = map.optionalFrom([
+                    "a",
+                    "b",
+                    "c",
+                ])
+            }
+        }
+
+        let test = Test.from(["b": "foo"])!
+        XCTAssertTrue(test.string == "foo")
+    }
+
+    func testMappingArrayOfOptionalFieldsReturnsNil() {
+        struct Test: Mappable {
+            let string: String?
+            init(map: Mapper) throws {
+                self.string = map.optionalFrom([
+                    "a",
+                    "b",
+                ])
+            }
+        }
+
+        let test = Test.from([:])!
+        XCTAssertNil(test.string)
+    }
+
+    // This is horrible. But currently, because of having multiple generic functions with
+    // similar type constraints, Swift incorrect infers the types of this. This is here
+    // as a sanity check. Once this test breaks we *could* remove `optionalFrom(fields: [String])`
+    // which was added to work around this problem.
+    func testNilCoalescingIsBroken() {
+        struct Test: Mappable {
+            let string: String?
+            init(map: Mapper) throws {
+                self.string = map.optionalFrom("a") ?? map.optionalFrom("b") ?? map.optionalFrom("c")
+            }
+        }
+
+        let test = Test.from(["b": "foo"])!
+        XCTAssertNil(test.string)
+    }
 }


### PR DESCRIPTION
This adds a new `optionalFrom` variant that takes an array of fields and
returns the first field which is non-nil from the data source. This was
added because of a swift bug with `??`. See the comment in the tests for
more context
