### PR TITLE
Compile-time checking for Mapper compatibility.

### DIFF
--- a/Mapper/Convertible.swift
+++ b/Mapper/Convertible.swift
@@ -41,3 +41,23 @@ public protocol Convertible {
      */
     static func fromMap(value: AnyObject?) throws -> ConvertedType
 }
+
+/**
+ This extension allows us to easily make native JSON types conform to Convertible.
+ */
+extension Convertible {
+    public static func fromMap(object: AnyObject?) throws -> ConvertedType {
+        guard let objectValue = object as? ConvertedType else {
+            throw MapperError()
+        }
+        return objectValue
+    }
+}
+
+// JSON native types
+extension String: Convertible {}
+extension Int: Convertible {}
+extension UInt: Convertible {}
+extension Float: Convertible {}
+extension Double: Convertible {}
+extension Bool: Convertible {}

--- a/Mapper/Mapper.swift
+++ b/Mapper/Mapper.swift
@@ -16,56 +16,6 @@ public struct Mapper {
         self.JSON = JSON
     }
 
-    // MARK: - T
-
-    /**
-     Get a typed value from the given key in the source data
-
-     - parameter key: The key to retrieve from the source data, can be an empty string to return the entire
-                      data set
-
-     - throws: `MapperError` if the value for the given key doesn't exist or cannot be converted to T
-
-     - returns: The value for the given key, if it can be converted to the expected type T
-     */
-    public func from<T>(field: String) throws -> T {
-        if let value = self.JSONFromField(field) as? T {
-            return value
-        }
-
-        throw MapperError()
-    }
-
-    /**
-     Get an optional typed value from the given key in the source data
-
-     - parameter key: The key to retrieve from the source data, can be an empty string to return the entire
-                      data set
-
-     - returns: The value for the given key, if it can be converted to the expected type T otherwise nil
-     */
-    public func optionalFrom<T>(field: String) -> T? {
-        return try? self.from(field)
-    }
-
-    /**
-     Get an optional value from the given keys and source data. This returns the first non-nil value produced
-     in order based on the array of fields
-
-     - parameter fields: The array of fields to check from the source data.
-
-     - returns: The first non-nil value to be produced from the array of fields, or nil if none exist
-    */
-    public func optionalFrom<T>(fields: [String]) -> T? {
-        for field in fields {
-            if let value: T = try? self.from(field) {
-                return value
-            }
-        }
-
-        return nil
-    }
-
     // MARK: - T: RawRepresentable
 
     /**

--- a/MapperTests/NormalValueTests.swift
+++ b/MapperTests/NormalValueTests.swift
@@ -50,19 +50,6 @@ final class NormalValueTests: XCTestCase {
         XCTAssertTrue(test.strings.count == 2)
     }
 
-    func testEmptyStringJSON() {
-        struct Test: Mappable {
-            let JSON: AnyObject
-            init(map: Mapper) throws {
-                try self.JSON = map.from("")
-            }
-        }
-
-        let JSON = ["a": "b", "c": "d"]
-        let test = try! Test(map: Mapper(JSON: JSON))
-        XCTAssertTrue((test.JSON as! [String: String]) == JSON)
-    }
-
     func testKeyPath() {
         struct Test: Mappable {
             let string: String

--- a/MapperTests/OptionalValueTests.swift
+++ b/MapperTests/OptionalValueTests.swift
@@ -50,42 +50,7 @@ final class OptionalValueTests: XCTestCase {
         XCTAssertTrue(test.strings!.count == 2)
     }
 
-    func testMappingArrayOfOptionalFieldsPicksNonNil() {
-        struct Test: Mappable {
-            let string: String?
-            init(map: Mapper) throws {
-                self.string = map.optionalFrom([
-                    "a",
-                    "b",
-                    "c",
-                ])
-            }
-        }
-
-        let test = Test.from(["b": "foo"])!
-        XCTAssertTrue(test.string == "foo")
-    }
-
-    func testMappingArrayOfOptionalFieldsReturnsNil() {
-        struct Test: Mappable {
-            let string: String?
-            init(map: Mapper) throws {
-                self.string = map.optionalFrom([
-                    "a",
-                    "b",
-                ])
-            }
-        }
-
-        let test = Test.from([:])!
-        XCTAssertNil(test.string)
-    }
-
-    // This is horrible. But currently, because of having multiple generic functions with
-    // similar type constraints, Swift incorrect infers the types of this. This is here
-    // as a sanity check. Once this test breaks we *could* remove `optionalFrom(fields: [String])`
-    // which was added to work around this problem.
-    func testNilCoalescingIsBroken() {
+    func testNilCoalescing() {
         struct Test: Mappable {
             let string: String?
             init(map: Mapper) throws {
@@ -94,6 +59,6 @@ final class OptionalValueTests: XCTestCase {
         }
 
         let test = Test.from(["b": "foo"])!
-        XCTAssertNil(test.string)
+        XCTAssertTrue(test.string == "foo")
     }
 }


### PR DESCRIPTION
Consider the following code:
```swift
       let url:NSURL = try map.from("url")
       let date:NSDate = try map.from("date")
```
Before this enhancement, the code compiles but throws an error at runtime because NSURL is Convertible but NSDate is not. 

After this enhancement, the second line fails to compile because the compiler is aware that NSDate is not Convertible.

This also fixes the problem with nil coalescing and eliminates the need for 
`optionalFrom(fields: [String])`