### PR TITLE
Implement optionalFrom array of keys for other types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@
 
 ## Bug Fixes
 
-- None
+- Fixed issue where `optionalFrom` with an array of keys was not
+  implemented for `Convertible` or other types.
+  [Keith Smiley](https://github.com/keith)
+  [#10](https://github.com/lyft/mapper/pull/10)
 
 # 1.0.0
 

--- a/Mapper/Mapper.swift
+++ b/Mapper/Mapper.swift
@@ -104,6 +104,24 @@ public struct Mapper {
         return try? self.from(field)
     }
 
+    /**
+     Get an optional value from the given keys and source data. This returns the first non-nil value produced
+     in order based on the array of fields
+
+     - parameter fields: The array of fields to check from the source data.
+
+     - returns: The first non-nil value to be produced from the array of fields, or nil if none exist
+    */
+    public func optionalFrom<T: RawRepresentable>(fields: [String]) -> T? {
+        for field in fields {
+            if let value: T = try? self.from(field) {
+                return value
+            }
+        }
+
+        return nil
+    }
+
     // MARK: - T: Mappable
 
     /**
@@ -179,6 +197,24 @@ public struct Mapper {
         return try? self.from(field)
     }
 
+    /**
+     Get an optional value from the given keys and source data. This returns the first non-nil value produced
+     in order based on the array of fields
+
+     - parameter fields: The array of fields to check from the source data.
+
+     - returns: The first non-nil value to be produced from the array of fields, or nil if none exist
+    */
+    public func optionalFrom<T: Mappable>(fields: [String]) -> T? {
+        for field in fields {
+            if let value: T = try? self.from(field) {
+                return value
+            }
+        }
+
+        return nil
+    }
+
     // MARK: - T: Convertible
 
     /**
@@ -243,6 +279,24 @@ public struct Mapper {
      */
     public func optionalFrom<T: Convertible where T == T.ConvertedType>(field: String) -> [T]? {
         return try? self.from(field)
+    }
+
+    /**
+     Get an optional value from the given keys and source data. This returns the first non-nil value produced
+     in order based on the array of fields
+
+     - parameter fields: The array of fields to check from the source data.
+
+     - returns: The first non-nil value to be produced from the array of fields, or nil if none exist
+    */
+    public func optionalFrom<T: Convertible where T == T.ConvertedType>(fields: [String]) -> T? {
+        for field in fields {
+            if let value: T = try? self.from(field) {
+                return value
+            }
+        }
+
+        return nil
     }
 
     // MARK: - Custom Transformation

--- a/MapperTests/ConvertibleValueTests.swift
+++ b/MapperTests/ConvertibleValueTests.swift
@@ -97,4 +97,16 @@ final class ConvertibleValueTests: XCTestCase {
         let test = try! Test(map: Mapper(JSON: ["urls": "not an array"]))
         XCTAssertNil(test.URLs)
     }
+
+    func testConvertibleArrayOfKeys() {
+        struct Test: Mappable {
+            let URL: NSURL?
+            init(map: Mapper) throws {
+                self.URL = map.optionalFrom(["a", "b"])
+            }
+        }
+
+        let test = try! Test(map: Mapper(JSON: ["a": "##", "b": "example.com"]))
+        XCTAssertTrue(test.URL?.absoluteString == "example.com")
+    }
 }

--- a/MapperTests/MappableValueTests.swift
+++ b/MapperTests/MappableValueTests.swift
@@ -131,4 +131,23 @@ final class MappableValueTests: XCTestCase {
         let test = try! Test(map: Mapper(JSON: ["nests": "not an array"]))
         XCTAssertNil(test.nests)
     }
+
+    func testMappableArrayOfKeys() {
+        struct Test: Mappable {
+            let nest: Nested?
+            init(map: Mapper) throws {
+                self.nest = map.optionalFrom(["a", "b"])
+            }
+        }
+
+        struct Nested: Mappable {
+            let string: String
+            init(map: Mapper) throws {
+                try self.string = map.from("string")
+            }
+        }
+
+        let test = try! Test(map: Mapper(JSON: ["a": ["foo": "bar"], "b": ["string": "hi"]]))
+        XCTAssertTrue(test.nest?.string == "hi")
+    }
 }

--- a/MapperTests/RawRepresentibleValueTests.swift
+++ b/MapperTests/RawRepresentibleValueTests.swift
@@ -97,4 +97,20 @@ final class RawRepresentibleValueTests: XCTestCase {
         let test = try! Test(map: Mapper(JSON: ["value": "not an int"]))
         XCTAssertNil(test.value)
     }
+
+    func testRawRepresentableArrayOfKeys() {
+        struct Test: Mappable {
+            let value: Value?
+            init(map: Mapper) throws {
+                self.value = map.optionalFrom(["a", "b"])
+            }
+        }
+
+        enum Value: String {
+            case First = "hi"
+        }
+
+        let test = try! Test(map: Mapper(JSON: ["a": "nope", "b": "hi"]))
+        XCTAssertTrue(test.value == .First)
+    }
 }


### PR DESCRIPTION
Previously `optionalFrom(fields: [String])` was only implemented for "normal" values. This adds implementations for `RawRepresentable`, `Convertible` and `Mappable`