### PR TITLE
Set 9.0 as Deployment target for tvOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 - Add Swift package manager support
   [Keith Smiley](https://github.com/keith)
   [#22](https://github.com/lyft/mapper/pull/22)
+- Changed tvOS target from 9.1 to 9.0 
+  [Ostap Taran](https://github.com/Austinate)
+  [#24](https://github.com/lyft/mapper/pull/24)
 
 ## Bug Fixes
 

--- a/Mapper.xcodeproj/project.pbxproj
+++ b/Mapper.xcodeproj/project.pbxproj
@@ -351,6 +351,7 @@
 				PRODUCT_NAME = Mapper;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Debug;
 		};
@@ -370,6 +371,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.Lyft.Mapper;
 				PRODUCT_NAME = Mapper;
 				SKIP_INSTALL = YES;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
tvOS Deployment target wasn't set, so mapper refused to compile with target set to 9.0 
Now should be fine :) 