### PR TITLE
Add test coverage travis build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 .LSOverride
 build/
 Carthage/Build
+coverage.txt
 DerivedData
 Icon
 run-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
     - os: osx
       env: ACTION=carthage
     - os: osx
+      env: ACTION=coverage
+    - os: osx
       env: ACTION=oss-osx
 
 language: objective-c

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ install-carthage:
 	brew rm carthage || true
 	brew install https://raw.githubusercontent.com/Homebrew/homebrew/96664cb3befd42f933de07d9fc0f61e8756d86c3/Library/Formula/carthage.rb
 
+install-coverage:
+	true
+
 install-oss-osx:
 	curl -sL https://gist.githubusercontent.com/kylef/5c0475ff02b7c7671d2a/raw/b07054552689910f79b3496221f7421a811f9f70/swiftenv-install.sh | bash
 
@@ -56,6 +59,19 @@ test-carthage:
 	ls Carthage/build/iOS/Mapper.framework
 	ls Carthage/build/tvOS/Mapper.framework
 	ls Carthage/build/watchOS/Mapper.framework
+
+test-coverage:
+	set -o pipefail && \
+		xcodebuild \
+		-project Mapper.xcodeproj \
+		-scheme Mapper \
+		-derivedDataPath build \
+		-enableCodeCoverage YES \
+		test \
+		| xcpretty -ct
+	rm -f coverage.txt
+	Resources/coverage.sh build/Build/Intermediates/CodeCoverage/Mapper/Coverage.profdata build
+	! grep -C 10 "^\s*0" coverage.txt
 
 test-oss-osx:
 	. ~/.swiftenv/init && swift build

--- a/Resources/coverage.sh
+++ b/Resources/coverage.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+profdata="$1"
+coverage_dir="$2"
+framework=$(find "$coverage_dir" -name "*.framework")
+xcrun llvm-cov show -instr-profile "$profdata" "$framework/Mapper" > "coverage.txt"

--- a/Tests/ConvertibleValueTests.swift
+++ b/Tests/ConvertibleValueTests.swift
@@ -109,4 +109,16 @@ final class ConvertibleValueTests: XCTestCase {
         let test = try! Test(map: Mapper(JSON: ["a": "##", "b": "example.com"]))
         XCTAssertTrue(test.URL?.absoluteString == "example.com")
     }
+
+    func testConvertibleArrayOfKeysReturnsNil() {
+        struct Test: Mappable {
+            let URL: NSURL?
+            init(map: Mapper) throws {
+                self.URL = map.optionalFrom(["a", "b"])
+            }
+        }
+
+        let test = try! Test(map: Mapper(JSON: [:]))
+        XCTAssertNil(test.URL)
+    }
 }

--- a/Tests/MappableValueTests.swift
+++ b/Tests/MappableValueTests.swift
@@ -150,4 +150,20 @@ final class MappableValueTests: XCTestCase {
         let test = try! Test(map: Mapper(JSON: ["a": ["foo": "bar"], "b": ["string": "hi"]]))
         XCTAssertTrue(test.nest?.string == "hi")
     }
+
+    func testMappableArrayOfKeysReturningNil() {
+        struct Test: Mappable {
+            let nest: Nested?
+            init(map: Mapper) throws {
+                self.nest = map.optionalFrom(["a", "b"])
+            }
+        }
+
+        struct Nested: Mappable {
+            init(map: Mapper) throws {}
+        }
+
+        let test = Test.from([:])!
+        XCTAssertNil(test.nest)
+    }
 }

--- a/Tests/OptionalValueTests.swift
+++ b/Tests/OptionalValueTests.swift
@@ -70,10 +70,7 @@ final class OptionalValueTests: XCTestCase {
         struct Test: Mappable {
             let string: String?
             init(map: Mapper) throws {
-                self.string = map.optionalFrom([
-                    "a",
-                    "b",
-                ])
+                self.string = map.optionalFrom(["a", "b"])
             }
         }
 

--- a/Tests/RawRepresentibleValueTests.swift
+++ b/Tests/RawRepresentibleValueTests.swift
@@ -113,4 +113,20 @@ final class RawRepresentibleValueTests: XCTestCase {
         let test = try! Test(map: Mapper(JSON: ["a": "nope", "b": "hi"]))
         XCTAssertTrue(test.value == .First)
     }
+
+    func testRawRepresentableArrayOfKeysReturningNil() {
+        struct Test: Mappable {
+            let value: Value?
+            init(map: Mapper) throws {
+                self.value = map.optionalFrom(["a", "b"])
+            }
+        }
+
+        enum Value: String {
+            case First = "hi"
+        }
+
+        let test = try! Test(map: Mapper(JSON: [:]))
+        XCTAssertNil(test.value)
+    }
 }


### PR DESCRIPTION
This parses the profdata file created from running the tests, and
verifies we have 100% coverage. The verification works by ensuring that
no line starts with a "0" which means it was hit 0 times during testing.

I've also added the few tests we were missing for 100% coverage.