### PR TITLE
Add Mappable creation from NSArray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 ## Enhancements
 
-- None
+- Add function for creating `Mappable`s from a `NSArray`
+  [Keith Smiley](https://github.com/keith)
+  [#27](https://github.com/lyft/mapper/pull/27)
 
 ## Bug Fixes
 

--- a/Sources/Mappable.swift
+++ b/Sources/Mappable.swift
@@ -36,11 +36,30 @@ public protocol Mappable {
      */
     @warn_unused_result
     static func from(JSON: NSDictionary) -> Self?
+
+    /**
+     Convenience method for creating Mappable objects from a NSArray
+
+     - parameter JSON: The JSON to create the objects from
+
+     - returns: An array of the created objects, or nil if creating threw
+     */
+    @warn_unused_result
+    static func from(JSON: NSArray) -> [Self]?
 }
 
 public extension Mappable {
     @warn_unused_result
     public static func from(JSON: NSDictionary) -> Self? {
         return try? self.init(map: Mapper(JSON: JSON))
+    }
+
+    @warn_unused_result
+    public static func from(JSON: NSArray) -> [Self]? {
+        if let array = JSON as? [NSDictionary] {
+            return try? array.map { try self.init(map: Mapper(JSON: $0)) }
+        }
+
+        return nil
     }
 }

--- a/Tests/InitializerTests.swift
+++ b/Tests/InitializerTests.swift
@@ -12,6 +12,9 @@ extension TestExtension: Mappable {
 }
 
 final class InitializerTests: XCTestCase {
+
+    // MARK: from NSDictionary
+
     func testCreatingInvalidFromJSON() {
         struct Test: Mappable {
             let string: String
@@ -36,7 +39,46 @@ final class InitializerTests: XCTestCase {
         XCTAssertTrue(test?.string == "Hi")
     }
 
-    // Testing http://www.openradar.me/23376350
+    // MARK: from NSArray
+
+    func testCreatingFromArrayOfJSON() {
+        struct Test: Mappable {
+            let string: String
+            init(map: Mapper) throws {
+                try self.string = map.from("string")
+            }
+        }
+
+        let tests = Test.from([["string": "Hi"], ["string": "Bye"]])
+        XCTAssertTrue(tests?.count == 2)
+    }
+
+    func testCreatingFromPartiallyInvalidArrayOfJSON() {
+        struct Test: Mappable {
+            let string: String
+            init(map: Mapper) throws {
+                try self.string = map.from("string")
+            }
+        }
+
+        let tests = Test.from([["string": "Hi"], ["nope": "Bye"]])
+        XCTAssertNil(tests)
+    }
+
+    func testCreatingFromInvalidArray() {
+        struct Test: Mappable {
+            let string: String
+            init(map: Mapper) throws {
+                try self.string = map.from("string")
+            }
+        }
+
+        let tests = Test.from(["hi"])
+        XCTAssertNil(tests)
+    }
+
+    // MARK: Testing http://www.openradar.me/23376350
+
     func testCreatingWithConformanceInExtension() {
         let test = TestExtension.from(["string": "Hi"])
         XCTAssertTrue(test?.string == "Hi")


### PR DESCRIPTION
This adds a new `from` function on `Mappable` in order to create
multiple objects from a `NSArray` of `NSDictionary`s.