### PR TITLE
WIP: Add creation of a non-optional array from NSArray

### DIFF
--- a/Sources/Mappable.swift
+++ b/Sources/Mappable.swift
@@ -46,6 +46,17 @@ public protocol Mappable {
      */
     @warn_unused_result
     static func from(JSON: NSArray) -> [Self]?
+    
+    /**
+     Convenience method for creating Mappable objects from a NSArray. 
+     This method uses flatMap to ignore objects that throw.
+     
+     - parameter JSON: The JSON to create the objects from
+     
+     - returns: An array of the created objects, or [] if unable to create from the NSArray
+     */
+    @warn_unused_result
+    static func from(JSON: NSArray) -> [Self]
 }
 
 public extension Mappable {
@@ -61,5 +72,14 @@ public extension Mappable {
         }
 
         return nil
+    }
+    
+    @warn_unused_result
+    public static func from(JSON: NSArray) -> [Self] {
+        if let array = JSON as? [NSDictionary] {
+            return array.flatMap { try? self.init(map: Mapper(JSON: $0)) }
+        }
+        
+        return []
     }
 }

--- a/Tests/InitializerTests.swift
+++ b/Tests/InitializerTests.swift
@@ -39,7 +39,7 @@ final class InitializerTests: XCTestCase {
         XCTAssertTrue(test?.string == "Hi")
     }
 
-    // MARK: from NSArray
+    // MARK: from NSArray as Optional
 
     func testCreatingFromArrayOfJSON() {
         struct Test: Mappable {
@@ -49,7 +49,7 @@ final class InitializerTests: XCTestCase {
             }
         }
 
-        let tests = Test.from([["string": "Hi"], ["string": "Bye"]])
+        let tests: [Test]? = Test.from([["string": "Hi"], ["string": "Bye"]])
         XCTAssertTrue(tests?.count == 2)
     }
 
@@ -61,7 +61,7 @@ final class InitializerTests: XCTestCase {
             }
         }
 
-        let tests = Test.from([["string": "Hi"], ["nope": "Bye"]])
+        let tests: [Test]? = Test.from([["string": "Hi"], ["nope": "Bye"]])
         XCTAssertNil(tests)
     }
 
@@ -73,8 +73,46 @@ final class InitializerTests: XCTestCase {
             }
         }
 
-        let tests = Test.from(["hi"])
+        let tests: [Test]? = Test.from(["hi"])
         XCTAssertNil(tests)
+    }
+    
+    // MARK: from NSArray as non-Optional
+    
+    func testCreatingNonOptionalFromArrayOfJSON() {
+        struct Test: Mappable {
+            let string: String
+            init(map: Mapper) throws {
+                try self.string = map.from("string")
+            }
+        }
+        
+        let tests: [Test] = Test.from([["string": "Hi"], ["string": "Bye"]])
+        XCTAssertTrue(tests.count == 2)
+    }
+    
+    func testCreatingNonOptionalFromPartiallyInvalidArrayOfJSON() {
+        struct Test: Mappable {
+            let string: String
+            init(map: Mapper) throws {
+                try self.string = map.from("string")
+            }
+        }
+        
+        let tests: [Test] = Test.from([["string": "Hi"], ["nope": "Bye"]])
+        XCTAssertTrue(tests.count == 1)
+    }
+    
+    func testCreatingNonOptionalFromInvalidArray() {
+        struct Test: Mappable {
+            let string: String
+            init(map: Mapper) throws {
+                try self.string = map.from("string")
+            }
+        }
+        
+        let tests: [Test] = Test.from(["hi"])
+        XCTAssertTrue(tests.count == 0)
     }
 
     // MARK: Testing http://www.openradar.me/23376350


### PR DESCRIPTION
The goal is to have two versions of .from(JSON: NSArray) — one that returns nil if any of the objects throw, and one that simply discards objects that throw, but always returns an array that contains the objects that could be created.

I've come across a strange issue in the tests though, specifically `testCreatingFromInvalidArray` and `testCreatingFromPartiallyInvalidArrayOfJSON`. The .from calls seem to prefer the non-optional version that returns an array, instead of the optional version which returns nil if any object creation fails. If you command-click on .from in Xcode, it also leads you to the non-optional version. 

Sorry if my explanation is confusing, let me know if you need any clarification!