### PR TITLE
Map from RawRepresentable Enum arrays

### DIFF
--- a/Sources/Mapper.swift
+++ b/Sources/Mapper.swift
@@ -134,7 +134,7 @@ public struct Mapper {
 
      This allows you to transparently have  arrays of RawRepresntable values
 
-     Note: If any value in the array is invalid (not convertible to the enum's raw representation ), the 
+     Note: If any value in the array is invalid (not convertible to the enum's raw representation ), the
      value is set to nil.
 
      - parameter key: The key to retrieve from the source data, can be an empty string to return the entire

--- a/Sources/Mapper.swift
+++ b/Sources/Mapper.swift
@@ -129,6 +129,34 @@ public struct Mapper {
         return nil
     }
 
+    /**
+     Get an array of RawRepresntable values from the given key in the source data
+
+     This allows you to transparently have  arrays of RawRepresntable values
+
+     Note: If any value in the array is invalid (convertible to the enum's raw representation ), this method
+     throws
+
+     - parameter key: The key to retrieve from the source data, can be an empty string to return the entire
+     data set
+
+     - throws: `MapperError` if the value for the given key doesn't exist or cannot be converted to [T]
+     this mean Mapper throws if the given value is also not an array of values that can be used to intialize T
+
+     - returns: The value for the given key, if it can be converted to the expected type [T]
+     */
+    @warn_unused_result
+    public func from<T: RawRepresentable>(field: String) throws -> [T] {
+        if let JSON = self.JSONFromField(field) as? [T.RawValue] {
+            return try JSON.map {
+                guard let value = T(rawValue: $0) else  { throw MapperError() }
+                return value
+            }
+        }
+
+        throw MapperError()
+    }
+
     // MARK: - T: Mappable
 
     /**

--- a/Sources/Mapper.swift
+++ b/Sources/Mapper.swift
@@ -134,8 +134,8 @@ public struct Mapper {
 
      This allows you to transparently have  arrays of RawRepresntable values
 
-     Note: If any value in the array is invalid (convertible to the enum's raw representation ), this method
-     throws
+     Note: If any value in the array is invalid (not convertible to the enum's raw representation ), the 
+     value is set to nil.
 
      - parameter key: The key to retrieve from the source data, can be an empty string to return the entire
      data set
@@ -146,11 +146,14 @@ public struct Mapper {
      - returns: The value for the given key, if it can be converted to the expected type [T]
      */
     @warn_unused_result
-    public func from<T: RawRepresentable>(field: String) throws -> [T] {
-        if let JSON = self.JSONFromField(field) as? [T.RawValue] {
-            return try JSON.map {
-                guard let value = T(rawValue: $0) else  { throw MapperError() }
-                return value
+    public func from<T: RawRepresentable>(field: String) throws -> [T?] {
+        if let JSON = self.JSONFromField(field) as? [AnyObject] {
+            return JSON.map { value in
+                if let value = value as? T.RawValue {
+                    return T(rawValue: value)
+                } else {
+                    return nil
+                }
             }
         }
 

--- a/Tests/RawRepresentibleValueTests.swift
+++ b/Tests/RawRepresentibleValueTests.swift
@@ -129,4 +129,45 @@ final class RawRepresentibleValueTests: XCTestCase {
         let test = try! Test(map: Mapper(JSON: [:]))
         XCTAssertNil(test.value)
     }
+
+    func testRawRepresentableArray() {
+        struct Test: Mappable {
+            let values: [Value]
+            init(map: Mapper) throws {
+                self.values = try map.from("values")
+            }
+        }
+        enum Value: String {
+            case ValueA = "a"
+            case ValueB = "b"
+            case ValueC = "c"
+        }
+        let json: NSDictionary = ["values": ["a", "b", "c", "a"]]
+
+        let test = try! Test(map: Mapper(JSON: json))
+        XCTAssert(test.values[0] == Value.ValueA)
+        XCTAssert(test.values[1] == Value.ValueB)
+        XCTAssert(test.values[2] == Value.ValueC)
+        XCTAssert(test.values[3] == Value.ValueA)
+    }
+
+    func testRawRepresentableInvalidArray() {
+        struct Test: Mappable {
+            let values: [Value]
+            init(map: Mapper) throws {
+                self.values = try map.from("values")
+            }
+        }
+        enum Value: String {
+            case ValueA = "a"
+            case ValueB = "b"
+            case ValueC = "c"
+        }
+        let json: NSDictionary = ["values": ["a", 1, "c", "a"]]
+
+        do {
+            let _ = try Test(map: Mapper(JSON: json))
+            XCTFail("Expecting Failure")
+        } catch { }
+    }
 }

--- a/Tests/RawRepresentibleValueTests.swift
+++ b/Tests/RawRepresentibleValueTests.swift
@@ -134,7 +134,7 @@ final class RawRepresentibleValueTests: XCTestCase {
         struct Test: Mappable {
             let values: [Value]
             init(map: Mapper) throws {
-                self.values = try map.from("values")
+                self.values = try map.from("values").flatMap { $0 }
             }
         }
         enum Value: String {
@@ -144,18 +144,22 @@ final class RawRepresentibleValueTests: XCTestCase {
         }
         let json: NSDictionary = ["values": ["a", "b", "c", "a"]]
 
-        let test = try! Test(map: Mapper(JSON: json))
-        XCTAssert(test.values[0] == Value.ValueA)
-        XCTAssert(test.values[1] == Value.ValueB)
-        XCTAssert(test.values[2] == Value.ValueC)
-        XCTAssert(test.values[3] == Value.ValueA)
+        do {
+            let test = try Test(map: Mapper(JSON: json))
+            XCTAssert(test.values[0] == Value.ValueA)
+            XCTAssert(test.values[1] == Value.ValueB)
+            XCTAssert(test.values[2] == Value.ValueC)
+            XCTAssert(test.values[3] == Value.ValueA)
+        } catch {
+            XCTFail("Expecting success")
+        }
     }
 
-    func testRawRepresentableInvalidArray() {
+    func testRawRepresentableInvalidKey() {
         struct Test: Mappable {
             let values: [Value]
             init(map: Mapper) throws {
-                self.values = try map.from("values")
+                self.values = try map.from("values").flatMap { $0 }
             }
         }
         enum Value: String {
@@ -163,11 +167,36 @@ final class RawRepresentibleValueTests: XCTestCase {
             case ValueB = "b"
             case ValueC = "c"
         }
-        let json: NSDictionary = ["values": ["a", 1, "c", "a"]]
+        let json: NSDictionary = ["invalid": ["a", "b", "c", "a"]]
 
         do {
             let _ = try Test(map: Mapper(JSON: json))
             XCTFail("Expecting Failure")
         } catch { }
+    }
+
+    func testRawRepresentableArrayWithInvalidElements() {
+        struct Test: Mappable {
+            let values: [Value]
+            init(map: Mapper) throws {
+                self.values = try map.from("values").flatMap { $0 }
+            }
+        }
+        enum Value: String {
+            case ValueA = "a"
+            case ValueB = "b"
+            case ValueC = "c"
+        }
+        let json: NSDictionary = ["values": ["a", "b", 1, "a", "z"]]
+
+        do {
+            let test = try Test(map: Mapper(JSON: json))
+            XCTAssert(test.values.count == 3)
+            XCTAssert(test.values[0] == Value.ValueA)
+            XCTAssert(test.values[1] == Value.ValueB)
+            XCTAssert(test.values[2] == Value.ValueA)
+        } catch {
+            XCTFail("Expecting success")
+        }
     }
 }


### PR DESCRIPTION
Allow mapping from arrays of enums. For example:

```
enum Value: String {
  case A = "a"
  case B = "b"
  case C = "c"
}

let json: NSDictionary = ["values": ["a", "b", "c", "a"]]
let map = Mapper(JSON: json)

let values: [Value] = map.from("values")

```
