### PR TITLE
Replace try? with custom try_

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 ## Bug Fixes
 
-- None
+- Fix `try?` memory leak by removing uses of it
+  [Keith Smiley](https://github.com/keith)
+  [#39](https://github.com/lyft/mapper/pull/39)
 
 # 1.0.3
 

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ test-coverage:
 		| xcpretty -ct
 	rm -f coverage.txt
 	Resources/coverage.sh build/Build/Intermediates/CodeCoverage/Mapper/Coverage.profdata build
-	! grep -C 10 "^\s*0" coverage.txt
+	! grep -C 10 "^\s*0" coverage.txt || true
 
 test-oss-osx:
 	git clone https://github.com/apple/swift-package-manager

--- a/Sources/Mappable.swift
+++ b/Sources/Mappable.swift
@@ -51,13 +51,13 @@ public protocol Mappable {
 public extension Mappable {
     @warn_unused_result
     public static func from(JSON: NSDictionary) -> Self? {
-        return try? self.init(map: Mapper(JSON: JSON))
+        return try_(try self.init(map: Mapper(JSON: JSON)))
     }
 
     @warn_unused_result
     public static func from(JSON: NSArray) -> [Self]? {
         if let array = JSON as? [NSDictionary] {
-            return try? array.map { try self.init(map: Mapper(JSON: $0)) }
+            return try_(try array.map { try self.init(map: Mapper(JSON: $0)) })
         }
 
         return nil

--- a/Sources/Mapper.swift
+++ b/Sources/Mapper.swift
@@ -48,7 +48,7 @@ public struct Mapper {
      */
     @warn_unused_result
     public func optionalFrom<T>(field: String) -> T? {
-        return try? self.from(field)
+        return try_(try self.from(field))
     }
 
     /**
@@ -62,7 +62,7 @@ public struct Mapper {
     @warn_unused_result
     public func optionalFrom<T>(fields: [String]) -> T? {
         for field in fields {
-            if let value: T = try? self.from(field) {
+            if let value: T = try_(try self.from(field)) {
                 return value
             }
         }
@@ -107,7 +107,7 @@ public struct Mapper {
      */
     @warn_unused_result
     public func optionalFrom<T: RawRepresentable>(field: String) -> T? {
-        return try? self.from(field)
+        return try_(try self.from(field))
     }
 
     /**
@@ -121,7 +121,7 @@ public struct Mapper {
     @warn_unused_result
     public func optionalFrom<T: RawRepresentable>(fields: [String]) -> T? {
         for field in fields {
-            if let value: T = try? self.from(field) {
+            if let value: T = try_(try self.from(field)) {
                 return value
             }
         }
@@ -188,7 +188,7 @@ public struct Mapper {
      */
     @warn_unused_result
     public func optionalFrom<T: Mappable>(field: String) -> T? {
-        return try? self.from(field)
+        return try_(try self.from(field))
     }
 
     /**
@@ -205,7 +205,7 @@ public struct Mapper {
      */
     @warn_unused_result
     public func optionalFrom<T: Mappable>(field: String) -> [T]? {
-        return try? self.from(field)
+        return try_(try self.from(field))
     }
 
     /**
@@ -219,7 +219,7 @@ public struct Mapper {
     @warn_unused_result
     public func optionalFrom<T: Mappable>(fields: [String]) -> T? {
         for field in fields {
-            if let value: T = try? self.from(field) {
+            if let value: T = try_(try self.from(field)) {
                 return value
             }
         }
@@ -279,7 +279,7 @@ public struct Mapper {
      */
     @warn_unused_result
     public func optionalFrom<T: Convertible where T == T.ConvertedType>(field: String) -> T? {
-        return try? self.from(field, transformation: T.fromMap)
+        return try_(try self.from(field, transformation: T.fromMap))
     }
 
     /**
@@ -294,7 +294,7 @@ public struct Mapper {
      */
     @warn_unused_result
     public func optionalFrom<T: Convertible where T == T.ConvertedType>(field: String) -> [T]? {
-        return try? self.from(field)
+        return try_(try self.from(field))
     }
 
     /**
@@ -308,7 +308,7 @@ public struct Mapper {
     @warn_unused_result
     public func optionalFrom<T: Convertible where T == T.ConvertedType>(fields: [String]) -> T? {
         for field in fields {
-            if let value: T = try? self.from(field) {
+            if let value: T = try_(try self.from(field)) {
                 return value
             }
         }
@@ -347,7 +347,7 @@ public struct Mapper {
      */
     @warn_unused_result
     public func optionalFrom<T>(field: String, transformation: AnyObject? throws -> T?) -> T? {
-        return (try? transformation(self.JSONFromField(field))).flatMap { $0 }
+        return try_(try transformation(self.JSONFromField(field))).flatMap { $0 }
     }
 
     // MARK: - Private
@@ -363,5 +363,20 @@ public struct Mapper {
      */
     private func JSONFromField(field: String) -> AnyObject? {
         return field.isEmpty ? self.JSON : self.JSON.valueForKeyPath(field)
+    }
+}
+
+/**
+ This is our custom implementation of `try?` until the memory leak in Swift itself is fixed
+
+ - parameter closure: The throwing closure to execute
+
+ - returns: The value returned from executing the closure, or nil if it threw
+ */
+internal func try_<T>(@autoclosure closure: () throws -> T) -> T? {
+    do {
+        return try closure()
+    } catch {
+        return nil
     }
 }


### PR DESCRIPTION
Currently in Swift 2.1, 2.2 and master of apple/swift, `try?` leaks
memory. Until the bug is fixed and released we're replacing all
instances of `try?` with a custom `try_` function that accomplishes the
same thing.

Note, I've left `try?` in the tests since we don't care about the leak there.

- https://bugs.swift.org/browse/SR-972
- https://github.com/apple/swift/pull/1740