### PR TITLE
Implement more descriptive MapperError

### DIFF
--- a/Sources/Errors.swift
+++ b/Sources/Errors.swift
@@ -4,7 +4,11 @@
 
  Custom implementations of Mappable, Convertible, or transformation functions can throw any error they desire
  */
-public struct MapperError: ErrorType {
+public enum MapperError: ErrorType {
+    case MapError(String)
+
     @warn_unused_result
-    public init() {}
+    public init(message: String) {
+        self = .MapError(message)
+    }
 }

--- a/Sources/Mapper.swift
+++ b/Sources/Mapper.swift
@@ -35,7 +35,7 @@ public struct Mapper {
             return value
         }
 
-        throw MapperError()
+        throw MapperError(message: "Can't convert value of field '\(field)' to \(T.self)")
     }
 
     /**
@@ -92,7 +92,7 @@ public struct Mapper {
             return value
         }
 
-        throw MapperError()
+        throw MapperError(message: "Can't convert value of field '\(field)' to \(T.self)")
     }
 
     /**
@@ -149,7 +149,7 @@ public struct Mapper {
             return try T(map: Mapper(JSON: JSON))
         }
 
-        throw MapperError()
+        throw MapperError(message: "Can't convert value of field '\(field)' to \(T.self)")
     }
 
     /**
@@ -173,7 +173,7 @@ public struct Mapper {
             return try JSON.map { try T(map: Mapper(JSON: $0)) }
         }
 
-        throw MapperError()
+        throw MapperError(message: "Can't convert value of field '\(field)' to [\(T.self)]")
     }
 
     /**
@@ -264,7 +264,7 @@ public struct Mapper {
             return try JSON.map(T.fromMap)
         }
 
-        throw MapperError()
+        throw MapperError(message: "Can't convert value of field '\(field)' to [\(T.self)]")
     }
 
     /**

--- a/Sources/NSURL+Convertible.swift
+++ b/Sources/NSURL+Convertible.swift
@@ -13,6 +13,6 @@ extension NSURL: Convertible {
             return URL
         }
 
-        throw MapperError()
+        throw MapperError(message: "Can't convert value '\(value)' to \(NSURL.self)")
     }
 }

--- a/Sources/Transform+Dictionary.swift
+++ b/Sources/Transform+Dictionary.swift
@@ -52,7 +52,7 @@ public extension Transform {
     {
         return { object in
             guard let objects = object as? [NSDictionary] else {
-                throw MapperError()
+                throw MapperError(message: "Can't cast '\(object)' to [NSDictionary]")
             }
 
             var dictionary: [U: T] = [:]

--- a/Tests/Mapper/CustomTransformationTests.swift
+++ b/Tests/Mapper/CustomTransformationTests.swift
@@ -25,7 +25,7 @@ final class CustomTransformationTests: XCTestCase {
             let value: Int
             init(map: Mapper) throws {
                 try value = map.from("foo", transformation: { object in
-                    throw MapperError()
+                    throw MapperError(message: "Failed")
                 })
             }
         }
@@ -62,7 +62,7 @@ final class CustomTransformationTests: XCTestCase {
         struct Test: Mappable {
             let string: String?
             init(map: Mapper) throws {
-                string = map.optionalFrom("foo", transformation: { _ in throw MapperError() })
+                string = map.optionalFrom("foo", transformation: { _ in throw MapperError(message: "Failed") })
             }
         }
 

--- a/Tests/Mapper/InitializerTests.swift
+++ b/Tests/Mapper/InitializerTests.swift
@@ -83,4 +83,29 @@ final class InitializerTests: XCTestCase {
         let test = TestExtension.from(["string": "Hi"])
         XCTAssertTrue(test?.string == "Hi")
     }
+    
+    func testThrowingMapErrorForMissingField() {
+        struct Test: Mappable {
+            let field1: String
+            let field2: String
+            let field3: String
+            
+            init(map: Mapper) throws {
+                try self.field1 = map.from("field1")
+                try self.field2 = map.from("field2")
+                try self.field3 = map.from("field3")
+            }
+        }
+        
+        let mapper = Mapper(JSON: ["field1": "Hi", "field3": "Yes"])
+        
+        
+        do {
+            let _ = try Test(map: mapper)
+        } catch MapperError.MapError(let message) {
+            XCTAssertEqual(message, "Can't convert value of field 'field2' to String")
+        } catch {
+            XCTFail("Catched error \"\(error)\", but not the expected: \"\(MapperError.MapError)\"")
+        }
+    }
 }


### PR DESCRIPTION
This PR inspired by @litso's comment https://github.com/lyft/mapper/issues/31#issue-131460647

It allows you to print out the map error and see what went south. Especially useful when you are mapping a number of properties in init:

```swift

struct Test: Mappable {
            let field1: String
            let field2: String
            let field3: String
            
            init(map: Mapper) throws {
                try self.field1 = map.from("field1")
                try self.field2 = map.from("field2")
                try self.field3 = map.from("field3")
            }
        }
        
        let mapper = Mapper(JSON: ["field1": "Hi", "field3": "Yes"])
        
        
        do {
            let test = try Test(map: mapper)
            ...
            
        } catch (let error) {
           print(error)
        }
```

 Prints out the following line in the console:
```
MapperError.MapError("Can't convert value of field 'field2' to String")
```


Closes lyft/mapper#31