### PR TITLE
Update docstrings for correct parameter names

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ extension CLLocationCoordinate2D: Convertible {
       let latitude = location["lat"] as? Double,
       let longitude = location["lng"] as? Double else
       {
-         throw MapperError()
+         throw MapperError.ConvertibleError(value: value, type: [String: Double].self)
       }
 
       return CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
@@ -128,7 +128,7 @@ let place = Place.from(JSON)
 ```swift
 private func extractFirstName(object: AnyObject?) throws -> String {
   guard let fullName = object as? String else {
-    throw MapperError()
+    throw MapperError.ConvertibleError(value: object, type: String.self)
   }
 
   let parts = fullName.characters.split { $0 == " " }.map(String.init)
@@ -136,7 +136,7 @@ private func extractFirstName(object: AnyObject?) throws -> String {
     return firstName
   }
 
-  throw MapperError()
+  throw MapperError.CustomError(field: nil, message: "Couldn't split the string!")
 }
 
 struct User: Mappable {

--- a/Sources/Convertible.swift
+++ b/Sources/Convertible.swift
@@ -32,10 +32,10 @@ public protocol Convertible {
      to cast the value to anything you'd like, and perform any manipulation on it (don't use this as a
      conversion mechanism, instead see Transform)
 
-     - parameter value: Any value (probably from the data source's value for the given key) to create
+     - parameter value: Any value (probably from the data source's value for the given field) to create
                         the expected object with
 
-     - throws: Any error from your custom implementation, `MapperError` is recommended
+     - throws: Any error from your custom implementation, MapperError.ConvertibleError is recommended
 
      - returns: The successfully created value from the given input
      */

--- a/Sources/Mapper.swift
+++ b/Sources/Mapper.swift
@@ -20,15 +20,15 @@ public struct Mapper {
     // MARK: - T
 
     /**
-     Get a typed value from the given key in the source data
+     Get a typed value from the given field in the source data
 
-     - parameter key: The key to retrieve from the source data, can be an empty string to return the entire
-                      data set
+     - parameter field: The field to retrieve from the source data, can be an empty string to return the
+                        entire data set
 
      - throws: MapperError.MissingFieldError if the field doesn't exist
      - throws: MapperError.TypeMismatchError if the value exists with the incorrect type
 
-     - returns: The value for the given key, if it can be converted to the expected type T
+     - returns: The value for the given field, if it can be converted to the expected type T
      */
     @warn_unused_result
     public func from<T>(field: String) throws -> T {
@@ -41,12 +41,12 @@ public struct Mapper {
     }
 
     /**
-     Get an optional typed value from the given key in the source data
+     Get an optional typed value from the given field in the source data
 
-     - parameter key: The key to retrieve from the source data, can be an empty string to return the entire
-                      data set
+     - parameter field: The field to retrieve from the source data, can be an empty string to return the
+                        entire data set
 
-     - returns: The value for the given key, if it can be converted to the expected type T otherwise nil
+     - returns: The value for the given field, if it can be converted to the expected type T otherwise nil
      */
     @warn_unused_result
     public func optionalFrom<T>(field: String) -> T? {
@@ -54,8 +54,8 @@ public struct Mapper {
     }
 
     /**
-     Get an optional value from the given keys and source data. This returns the first non-nil value produced
-     in order based on the array of fields
+     Get an optional value from the given fields and source data. This returns the first non-nil value
+     produced in order based on the array of fields
 
      - parameter fields: The array of fields to check from the source data.
 
@@ -75,19 +75,19 @@ public struct Mapper {
     // MARK: - T: RawRepresentable
 
     /**
-     Get a RawRepresentable value from the given key in the source data
+     Get a RawRepresentable value from the given field in the source data
 
      This allows you to transparently create instances of enums and other RawRepresentables from source data
 
-     - parameter key: The key to retrieve from the source data, can be an empty string to return the entire
-                      data set
+     - parameter field: The field to retrieve from the source data, can be an empty string to return the
+                        entire data set
 
      - throws: MapperError.MissingFieldError    if the field doesn't exist
      - throws: MapperError.TypeMismatchError    if the value exists but doesn't match the type of the RawValue
      - throws: MapperError.InvalidRawValueError if the value exists with the correct type, but the type's
                                                 initializer fails with the passed rawValue
 
-     - returns: The value for the given key, if it can be converted to the expected type T
+     - returns: The value for the given field, if it can be converted to the expected type T
      */
     @warn_unused_result
     public func from<T: RawRepresentable>(field: String) throws -> T {
@@ -104,14 +104,14 @@ public struct Mapper {
     }
 
     /**
-     Get an optional RawRepresentable value from the given key in the source data
+     Get an optional RawRepresentable value from the given field in the source data
 
      This allows you to transparently create instances of enums and other RawRepresentables from source data
 
-     - parameter key: The key to retrieve from the source data, can be an empty string to return the entire
-                      data set
+     - parameter field: The field to retrieve from the source data, can be an empty string to return the
+                        entire data set
 
-     - returns: The value for the given key, if it can be converted to the expected type T otherwise nil
+     - returns: The value for the given field, if it can be converted to the expected type T otherwise nil
      */
     @warn_unused_result
     public func optionalFrom<T: RawRepresentable>(field: String) -> T? {
@@ -119,13 +119,13 @@ public struct Mapper {
     }
 
     /**
-     Get an optional value from the given keys and source data. This returns the first non-nil value produced
-     in order based on the array of fields
+     Get an optional value from the given fields and source data. This returns the first non-nil value
+     produced in order based on the array of fields
 
      - parameter fields: The array of fields to check from the source data.
 
      - returns: The first non-nil value to be produced from the array of fields, or nil if none exist
-    */
+     */
     @warn_unused_result
     public func optionalFrom<T: RawRepresentable>(fields: [String]) -> T? {
         for field in fields {
@@ -140,17 +140,17 @@ public struct Mapper {
     // MARK: - T: Mappable
 
     /**
-     Get a Mappable value from the given key in the source data
+     Get a Mappable value from the given field in the source data
 
      This allows you to transparently have nested Mappable values
 
-     - parameter key: The key to retrieve from the source data, can be an empty string to return the entire
-                      data set
+     - parameter field: The field to retrieve from the source data, can be an empty string to return the
+                        entire data set
 
      - throws: MapperError.MissingFieldError if the field doesn't exist
      - throws: MapperError.TypeMismatchError if the field exists but isn't an NSDictionary
 
-     - returns: The value for the given key, if it can be converted to the expected type T
+     - returns: The value for the given field, if it can be converted to the expected type T
      */
     @warn_unused_result
     public func from<T: Mappable>(field: String) throws -> T {
@@ -163,20 +163,20 @@ public struct Mapper {
     }
 
     /**
-     Get an array of Mappable values from the given key in the source data
+     Get an array of Mappable values from the given field in the source data
 
      This allows you to transparently have nested arrays of Mappable values
 
      Note: If any value in the array of NSDictionaries is invalid, this method throws
 
-     - parameter key: The key to retrieve from the source data, can be an empty string to return the entire
-                      data set
+     - parameter field: The field to retrieve from the source data, can be an empty string to return the
+                        entire data set
 
      - throws: MapperError.MissingFieldError if the field doesn't exist
      - throws: MapperError.TypeMismatchError if the field exists but isn't an array of NSDictionarys
      - throws: Any errors produced by the subsequent Mappable initializers
 
-     - returns: The value for the given key, if it can be converted to the expected type [T]
+     - returns: The value for the given field, if it can be converted to the expected type [T]
      */
     @warn_unused_result
     public func from<T: Mappable>(field: String) throws -> [T] {
@@ -189,14 +189,14 @@ public struct Mapper {
     }
 
     /**
-     Get an optional Mappable value from the given key in the source data
+     Get an optional Mappable value from the given field in the source data
 
      This allows you to transparently have nested Mappable values
 
-     - parameter key: The key to retrieve from the source data, can be an empty string to return the entire
-                      data set
+     - parameter field: The field to retrieve from the source data, can be an empty string to return the
+                        entire data set
 
-     - returns: The value for the given key, if it can be converted to the expected type T otherwise nil
+     - returns: The value for the given field, if it can be converted to the expected type T otherwise nil
      */
     @warn_unused_result
     public func optionalFrom<T: Mappable>(field: String) -> T? {
@@ -204,16 +204,16 @@ public struct Mapper {
     }
 
     /**
-     Get an optional array of Mappable values from the given key in the source data
+     Get an optional array of Mappable values from the given field in the source data
 
      This allows you to transparently have nested arrays of Mappable values
 
      Note: If any value in the provided array of NSDictionaries is invalid, this method returns nil
 
-     - parameter key: The key to retrieve from the source data, can be an empty string to return the entire
-                      data set
+     - parameter field: The field to retrieve from the source data, can be an empty string to return the
+                        entire data set
 
-     - returns: The value for the given key, if it can be converted to the expected type [T]
+     - returns: The value for the given field, if it can be converted to the expected type [T]
      */
     @warn_unused_result
     public func optionalFrom<T: Mappable>(field: String) -> [T]? {
@@ -221,13 +221,13 @@ public struct Mapper {
     }
 
     /**
-     Get an optional value from the given keys and source data. This returns the first non-nil value produced
-     in order based on the array of fields
+     Get an optional value from the given fields and source data. This returns the first non-nil value
+     produced in order based on the array of fields
 
      - parameter fields: The array of fields to check from the source data.
 
      - returns: The first non-nil value to be produced from the array of fields, or nil if none exist
-    */
+     */
     @warn_unused_result
     public func optionalFrom<T: Mappable>(fields: [String]) -> T? {
         for field in fields {
@@ -246,12 +246,12 @@ public struct Mapper {
 
      This transparently converts your types that conform to Convertible to properties on the Mappable type
 
-     - parameter key: The key to retrieve from the source data, can be an empty string to return the entire
-                      data set
+     - parameter field: The field to retrieve from the source data, can be an empty string to return the
+                        entire data set
 
      - throws: Any error produced by the custom Convertible implementation
 
-     - returns: The value for the given key, if it can be converted to the expected type T
+     - returns: The value for the given field, if it can be converted to the expected type T
      */
     @warn_unused_result
     public func from<T: Convertible where T == T.ConvertedType>(field: String) throws -> T {
@@ -263,14 +263,14 @@ public struct Mapper {
 
      This transparently converts your types that conform to Convertible to an array on the Mappable type
 
-     - parameter key: The key to retrieve from the source data, can be an empty string to return the entire
-                      data set
+     - parameter field: The field to retrieve from the source data, can be an empty string to return the
+                        entire data set
 
      - throws: MapperError.MissingFieldError if the field doesn't exist
      - throws: MapperError.TypeMismatchError if the field exists but isn't an array of AnyObject
      - throws: Any error produced by the subsequent Convertible implementations
 
-     - returns: The value for the given key, if it can be converted to the expected type [T]
+     - returns: The value for the given field, if it can be converted to the expected type [T]
      */
     @warn_unused_result
     public func from<T: Convertible where T == T.ConvertedType>(field: String) throws -> [T] {
@@ -287,10 +287,10 @@ public struct Mapper {
 
      This transparently converts your types that conform to Convertible to properties on the Mappable type
 
-     - parameter key: The key to retrieve from the source data, can be an empty string to return the entire
-                      data set
+     - parameter field: The field to retrieve from the source data, can be an empty string to return the
+                        entire data set
 
-     - returns: The value for the given key, if it can be converted to the expected type T otherwise nil
+     - returns: The value for the given field, if it can be converted to the expected type T otherwise nil
      */
     @warn_unused_result
     public func optionalFrom<T: Convertible where T == T.ConvertedType>(field: String) -> T? {
@@ -302,10 +302,10 @@ public struct Mapper {
 
      This transparently converts your types that conform to Convertible to an array on the Mappable type
 
-     - parameter key: The key to retrieve from the source data, can be an empty string to return the entire
-                      data set
+     - parameter field: The field to retrieve from the source data, can be an empty string to return the
+                        entire data set
 
-     - returns: The value for the given key, if it can be converted to the expected type [T]
+     - returns: The value for the given field, if it can be converted to the expected type [T]
      */
     @warn_unused_result
     public func optionalFrom<T: Convertible where T == T.ConvertedType>(field: String) -> [T]? {
@@ -313,13 +313,13 @@ public struct Mapper {
     }
 
     /**
-     Get an optional value from the given keys and source data. This returns the first non-nil value produced
-     in order based on the array of fields
+     Get an optional value from the given fields and source data. This returns the first non-nil value
+     produced in order based on the array of fields
 
      - parameter fields: The array of fields to check from the source data.
 
      - returns: The first non-nil value to be produced from the array of fields, or nil if none exist
-    */
+     */
     @warn_unused_result
     public func optionalFrom<T: Convertible where T == T.ConvertedType>(fields: [String]) -> T? {
         for field in fields {
@@ -334,16 +334,16 @@ public struct Mapper {
     // MARK: - Custom Transformation
 
     /**
-     Get a typed value from the given key by using the given transformation
+     Get a typed value from the given field by using the given transformation
 
-     - parameter key:            The key to retrieve from the source data, can be an empty string to return
+     - parameter field:          The field to retrieve from the source data, can be an empty string to return
                                  the entire data set
      - parameter transformation: The transformation function used to create the expected value
 
      - throws: Any exception thrown by the transformation function, if you're implementing the transformation
                function you should use `MapperError`, see the documentation there for more info
 
-     - returns: The value of type T for the given key, if the transformation function doesn't throw
+     - returns: The value of type T for the given field, if the transformation function doesn't throw
      */
     @warn_unused_result
     public func from<T>(field: String, transformation: AnyObject? throws -> T) rethrows -> T {
@@ -351,14 +351,14 @@ public struct Mapper {
     }
 
     /**
-     Get an optional typed value from the given key by using the given transformation
+     Get an optional typed value from the given field by using the given transformation
 
-     - parameter key:            The key to retrieve from the source data, can be an empty string to return
+     - parameter field:          The field to retrieve from the source data, can be an empty string to return
                                  the entire data set
      - parameter transformation: The transformation function used to create the expected value
 
-     - returns: The value of type T for the given key, if the transformation function doesn't throw otherwise
-                nil
+     - returns: The value of type T for the given field, if the transformation function doesn't throw
+                otherwise nil
      */
     @warn_unused_result
     public func optionalFrom<T>(field: String, transformation: AnyObject? throws -> T?) -> T? {
@@ -368,15 +368,15 @@ public struct Mapper {
     // MARK: - Private
 
     /**
-     Get the object for a given key. If an empty string is passed, return the entire data source. This
+     Get the object for a given field. If an empty string is passed, return the entire data source. This
      allows users to create objects from multiple fields in the top level of the data source
 
-     - parameter field: The key to extract from the data source, can be an empty string to return the entire
+     - parameter field: The field to extract from the data source, can be an empty string to return the entire
                         data source
 
      - throws: MapperError.MissingFieldError if the field doesn't exist
 
-     - returns: The object for the given key
+     - returns: The object for the given field
      */
     private func JSONFromField(field: String) throws -> AnyObject {
         if let value = field.isEmpty ? self.JSON : self.JSON.valueForKeyPath(field) {


### PR DESCRIPTION
At some point we switched from using `key` to using `field` but never
reflected those changes in the docstrings.