### PR TITLE
Make transformations throw MissingFieldErrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Breaking
 
-- None
+- Allow transformations to throw when the field is missing
+  [Keith Smiley](https://github.com/keith)
+  [#52](https://github.com/lyft/mapper/pull/52)
 
 ## Enhancements
 

--- a/Sources/Mapper.swift
+++ b/Sources/Mapper.swift
@@ -340,14 +340,15 @@ public struct Mapper {
                                  the entire data set
      - parameter transformation: The transformation function used to create the expected value
 
+     - throws: MapperError.MissingFieldError if the field doesn't exist
      - throws: Any exception thrown by the transformation function, if you're implementing the transformation
                function you should use `MapperError`, see the documentation there for more info
 
-     - returns: The value of type T for the given field, if the transformation function doesn't throw
+     - returns: The value of type T for the given field
      */
     @warn_unused_result
-    public func from<T>(field: String, transformation: AnyObject? throws -> T) rethrows -> T {
-        return try transformation(try? self.JSONFromField(field))
+    public func from<T>(field: String, transformation: AnyObject? throws -> T) throws -> T {
+        return try transformation(try self.JSONFromField(field))
     }
 
     /**

--- a/Tests/Mapper/CustomTransformationTests.swift
+++ b/Tests/Mapper/CustomTransformationTests.swift
@@ -6,7 +6,7 @@ final class CustomTransformationTests: XCTestCase {
         struct Test: Mappable {
             let value: Int
             init(map: Mapper) throws {
-                value = map.from("value", transformation: { thing in
+                value = try map.from("value", transformation: { thing in
                     if let a = thing as? Int {
                         return a + 1
                     } else {

--- a/Tests/Mapper/ErrorTests.swift
+++ b/Tests/Mapper/ErrorTests.swift
@@ -61,7 +61,7 @@ final class ErrorTests: XCTestCase {
 
     func testCustomError() {
         do {
-            let map = Mapper(JSON: [:])
+            let map = Mapper(JSON: ["string": "hi"])
             _ = try map.from("string", transformation: { _ in
                 throw MapperError.CustomError(field: "string", message: "hi")
             })
@@ -77,7 +77,7 @@ final class ErrorTests: XCTestCase {
 
     func testDeprecatedInitializer() {
         do {
-            let map = Mapper(JSON: [:])
+            let map = Mapper(JSON: ["string": 1])
             _ = try map.from("string", transformation: { _ in throw MapperError() })
             XCTFail()
         } catch MapperError.CustomError(let field, let message) {

--- a/Tests/Mapper/TransformTests.swift
+++ b/Tests/Mapper/TransformTests.swift
@@ -61,8 +61,15 @@ final class TransformTests: XCTestCase {
             }
         }
 
-        let test = try? Test(map: Mapper(JSON: [:]))
-        XCTAssertNil(test)
+        do {
+            _ = try Test(map: Mapper(JSON: ["examples": 1]))
+            XCTFail()
+        } catch MapperError.ConvertibleError(let value, let type) {
+            XCTAssert(value as? Int == 1)
+            XCTAssert(type == [NSDictionary].self)
+        } catch {
+            XCTFail()
+        }
     }
 
     func testToDictionaryOneInvalid() {
@@ -90,5 +97,17 @@ final class TransformTests: XCTestCase {
 
         let test = try? Test(map: Mapper(JSON: JSON))
         XCTAssertNil(test)
+    }
+
+    func testMissingFieldErrorFromTransformation() {
+        do {
+            let map = Mapper(JSON: [:])
+            let _: String = try map.from("foo", transformation: { _ in return "hi" })
+            XCTFail()
+        } catch MapperError.MissingFieldError(let field) {
+            XCTAssert(field == "foo")
+        } catch {
+            XCTFail()
+        }
     }
 }


### PR DESCRIPTION
When implementing custom errors I decided to make the transformation
function swallow `MissingFieldError`s since we were using `rethrows` and
it would have been a breaking API change. Now we're going to bump for a
breaking API change, and this is more true to what is actually going
wrong in order for the function to throw.

See previous conversation https://github.com/lyft/mapper/pull/48/files#r60854250
