### PR TITLE
Remove deprecated MapperError initializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Allow transformations to throw when the field is missing
   [Keith Smiley](https://github.com/keith)
   [#52](https://github.com/lyft/mapper/pull/52)
+- Remove the `MapperError` initializer
+  [Keith Smiley](https://github.com/keith)
+  [#53](https://github.com/lyft/mapper/pull/53)
 
 ## Enhancements
 

--- a/Sources/MapperError.swift
+++ b/Sources/MapperError.swift
@@ -16,10 +16,4 @@ public enum MapperError: ErrorType {
     case InvalidRawValueError(field: String, value: Any, type: Any.Type)
     case MissingFieldError(field: String)
     case TypeMismatchError(field: String, value: AnyObject, type: Any.Type)
-
-    @available(*, deprecated, message="MapperError initializer is deprecated. Use an enum case directly.")
-    @warn_unused_result
-    public init() {
-        self = .CustomError(field: nil, message: "Legacy MapperError initializer")
-    }
 }

--- a/Tests/Mapper/ErrorTests.swift
+++ b/Tests/Mapper/ErrorTests.swift
@@ -74,17 +74,4 @@ final class ErrorTests: XCTestCase {
             XCTFail()
         }
     }
-
-    func testDeprecatedInitializer() {
-        do {
-            let map = Mapper(JSON: ["string": 1])
-            _ = try map.from("string", transformation: { _ in throw MapperError() })
-            XCTFail()
-        } catch MapperError.CustomError(let field, let message) {
-            XCTAssertNil(field)
-            XCTAssertFalse(message.isEmpty)
-        } catch {
-            XCTFail()
-        }
-    }
 }


### PR DESCRIPTION
This was deprecated in the last release. Since we're preparing for a
release with breaking changes, I'm going to go ahead and remove this.