### PR TITLE
Add compile time safety for all types

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,6 +1,7 @@
 line_length:
   - 110
 disabled_rules:
+  - file_length
   - force_cast
   - force_try
   - nesting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Breaking
 
+- Require types to be `Convertible` in order to use them.
+  [Keith Smiley](https://github.com/keith)
+  [#59](https://github.com/lyft/mapper/pull/59)
 - Allow transformations to throw when the field is missing
   [Keith Smiley](https://github.com/keith)
   [#52](https://github.com/lyft/mapper/pull/52)

--- a/Mapper.xcodeproj/project.pbxproj
+++ b/Mapper.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		C201748E1BD5509D00E4FE18 /* Mapper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C20174831BD5509D00E4FE18 /* Mapper.framework */; };
+		C20586EC1CDEAD9900658A67 /* DefaultConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20586EB1CDEAD9900658A67 /* DefaultConvertible.swift */; };
 		C2B977A91CCD7AD800FDA451 /* ErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2B977A71CCD7AB200FDA451 /* ErrorTests.swift */; };
 		C2C036FA1C2B1A0B003FB853 /* Convertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2C036F31C2B1A0B003FB853 /* Convertible.swift */; };
 		C2C036FB1C2B1A0B003FB853 /* MapperError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2C036F41C2B1A0B003FB853 /* MapperError.swift */; };
@@ -39,6 +40,7 @@
 /* Begin PBXFileReference section */
 		C20174831BD5509D00E4FE18 /* Mapper.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Mapper.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C201748D1BD5509D00E4FE18 /* MapperTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MapperTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		C20586EB1CDEAD9900658A67 /* DefaultConvertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultConvertible.swift; sourceTree = "<group>"; };
 		C2B977A71CCD7AB200FDA451 /* ErrorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorTests.swift; sourceTree = "<group>"; };
 		C2C036D11C2B180D003FB853 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C2C036D41C2B180D003FB853 /* UniversalFramework_Base.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = UniversalFramework_Base.xcconfig; sourceTree = "<group>"; };
@@ -115,6 +117,7 @@
 			isa = PBXGroup;
 			children = (
 				C2C036F31C2B1A0B003FB853 /* Convertible.swift */,
+				C20586EB1CDEAD9900658A67 /* DefaultConvertible.swift */,
 				C2C036F51C2B1A0B003FB853 /* Mappable.swift */,
 				C2C036F61C2B1A0B003FB853 /* Mapper.swift */,
 				C2C036F41C2B1A0B003FB853 /* MapperError.swift */,
@@ -230,6 +233,7 @@
 				C2C036FD1C2B1A0B003FB853 /* Mapper.swift in Sources */,
 				C2C037001C2B1A0B003FB853 /* Transform.swift in Sources */,
 				C2C036FB1C2B1A0B003FB853 /* MapperError.swift in Sources */,
+				C20586EC1CDEAD9900658A67 /* DefaultConvertible.swift in Sources */,
 				C2C036FC1C2B1A0B003FB853 /* Mappable.swift in Sources */,
 				C2C036FA1C2B1A0B003FB853 /* Convertible.swift in Sources */,
 			);

--- a/Sources/DefaultConvertible.swift
+++ b/Sources/DefaultConvertible.swift
@@ -1,0 +1,37 @@
+/**
+ The DefaultConvertible protocol defines values that can be converted from JSON by conditionally downcasting
+
+ This means any value that you could use with `as?`. If you have other types that would work to be casted from
+ JSON by just using `value as? YourType` you should conform to this protocol in order to get the definition of
+ that for free.
+
+ The reason this is a separate protocol instead of just using a prtocol extension on Convertible is so other
+ Consumers of Convertible will still get an error if they don't implement `fromMap`
+ */
+public protocol DefaultConvertible: Convertible {}
+
+extension DefaultConvertible {
+    public static func fromMap(value: AnyObject?) throws -> ConvertedType {
+        if let object = value as? ConvertedType {
+            return object
+        }
+
+        throw MapperError.ConvertibleError(value: value, type: ConvertedType.self)
+    }
+}
+
+// MARK: - Default Conformances
+
+/// These Foundation conformances are acceptable since we already depend on Foundation. No other frameworks
+/// Should be important as part of Mapper for default conformances. Consumers should conform any other common
+/// Types in an extension in their own projects (e.g. `CGFloat`)
+import Foundation
+extension NSDictionary: DefaultConvertible {}
+extension NSArray: DefaultConvertible {}
+
+extension String: DefaultConvertible {}
+extension Int: DefaultConvertible {}
+extension UInt: DefaultConvertible {}
+extension Float: DefaultConvertible {}
+extension Double: DefaultConvertible {}
+extension Bool: DefaultConvertible {}

--- a/Tests/Mapper/ConvertibleValueTests.swift
+++ b/Tests/Mapper/ConvertibleValueTests.swift
@@ -1,6 +1,12 @@
 import Mapper
 import XCTest
 
+private struct Foo: Convertible {
+    static func fromMap(value: AnyObject?) throws -> Foo {
+        return Foo()
+    }
+}
+
 final class ConvertibleValueTests: XCTestCase {
     func testCreatingURL() {
         struct Test: Mappable {
@@ -120,5 +126,83 @@ final class ConvertibleValueTests: XCTestCase {
 
         let test = try! Test(map: Mapper(JSON: [:]))
         XCTAssertNil(test.URL)
+    }
+
+    func testDictionaryConvertible() {
+        struct Test: Mappable {
+            let dictionary: [String: Int]
+
+            init(map: Mapper) throws {
+                try self.dictionary = map.from("foo")
+            }
+        }
+
+        let test = Test.from(["foo": ["key": 1]])!
+        XCTAssertTrue(test.dictionary["key"] == 1)
+    }
+
+    func testOptionalDictionaryConvertible() {
+        struct Test: Mappable {
+            let dictionary: [String: Int]?
+
+            init(map: Mapper) throws {
+                self.dictionary = map.optionalFrom("foo")
+            }
+        }
+
+        let test = Test.from(["foo": ["key": 1]])!
+        XCTAssertTrue(test.dictionary?["key"] == 1)
+    }
+
+    func testDictionaryOfConvertibles() {
+        struct Test: Mappable {
+            let dictionary: [String: Foo]
+
+            init(map: Mapper) throws {
+                try self.dictionary = map.from("foo")
+            }
+        }
+
+        let test = Test.from(["foo": ["key": "value"]])
+        XCTAssertTrue(test?.dictionary.count > 0)
+    }
+
+    func testOptionalDictionaryConvertibleNil() {
+        struct Test: Mappable {
+            let dictionary: [String: Int]?
+
+            init(map: Mapper) throws {
+                self.dictionary = map.optionalFrom("foo")
+            }
+        }
+
+        let test = Test.from(["foo": ["key": "not int"]])!
+        XCTAssertNil(test.dictionary)
+    }
+
+    func testDictionaryConvertibleSingleInvalid() {
+        struct Test: Mappable {
+            let dictionary: [String: Int]
+
+            init(map: Mapper) throws {
+                try self.dictionary = map.from("foo")
+            }
+        }
+
+        let test = Test.from(["foo": ["key": 1, "key2": "not int"]])
+        XCTAssertNil(test)
+    }
+
+    func testDictionaryButInvalidJSON() {
+        struct Test: Mappable {
+            let dictionary: [String: Int]
+
+            init(map: Mapper) throws {
+                try self.dictionary = map.from("foo")
+            }
+        }
+
+        let test = Test.from(["foo": "not a dictionary"])
+        XCTAssertNil(test)
     }
 }

--- a/Tests/Mapper/ErrorTests.swift
+++ b/Tests/Mapper/ErrorTests.swift
@@ -3,14 +3,18 @@ import XCTest
 
 final class ErrorTests: XCTestCase {
     func testTypeMismatch() {
+        struct Test: Mappable {
+            init(map: Mapper) throws {}
+        }
+
         do {
             let map = Mapper(JSON: ["field": 1])
-            let _: String = try map.from("field")
+            let _: Test = try map.from("field")
             XCTFail()
         } catch MapperError.TypeMismatchError(let field, let value, let type) {
             XCTAssert(field == "field")
             XCTAssert(value as? Int == 1)
-            XCTAssert(type == String.self)
+            XCTAssert(type == NSDictionary.self)
         } catch {
             XCTFail()
         }

--- a/Tests/Mapper/NormalValueTests.swift
+++ b/Tests/Mapper/NormalValueTests.swift
@@ -14,6 +14,18 @@ final class NormalValueTests: XCTestCase {
         XCTAssertTrue(test.string == "Hello")
     }
 
+    func testMappingTimeInterval() {
+        struct Test: Mappable {
+            let string: NSTimeInterval
+            init(map: Mapper) throws {
+                try self.string = map.from("time")
+            }
+        }
+
+        let test = try! Test(map: Mapper(JSON: ["time": 123]))
+        XCTAssertTrue(test.string == 123)
+    }
+
     func testMappingMissingKey() {
         struct Test: Mappable {
             let string: String
@@ -52,7 +64,7 @@ final class NormalValueTests: XCTestCase {
 
     func testEmptyStringJSON() {
         struct Test: Mappable {
-            let JSON: AnyObject
+            let JSON: NSDictionary
             init(map: Mapper) throws {
                 try self.JSON = map.from("")
             }
@@ -85,5 +97,17 @@ final class NormalValueTests: XCTestCase {
 
         let test = try? Test(map: Mapper(JSON: ["strings": ["hi", 1]]))
         XCTAssertNil(test)
+    }
+
+    func testOptionalPropertyWithFrom() {
+        struct Test: Mappable {
+            let string: String?
+            init(map: Mapper) throws {
+                try self.string = map.from("string")
+            }
+        }
+
+        let test = try? Test(map: Mapper(JSON: ["string": "hi"]))
+        XCTAssertEqual(test?.string, "hi")
     }
 }


### PR DESCRIPTION
Previously Mapper worked by conditionally downcasting values to the
expected types. For example:

```
let string: String? = map.optionalFrom("field")
```

Would basically translate to:

```
JSON["field"] as? String?
```

This worked perfectly for many common types, such as `String` and `Int`.
But this became a problem when you used types that could not be
converted like this such as `NSDate`. Previously this line of code would
compile without any additions to Mapper:

```
let date: NSDate? = map.optionalFrom("field")
```

But since this would translate to:

```
JSON["field"] as? NSDate?
```

This would fail 100% of the time. But since it compiled it would leave
callers assuming that it could work. This is no longer the case. Now if
you attempt to cast to a type that doesn't conform to `Convertible`
(unless it's `RawRepresentable` or you're using a transformation) it
will fail to compile.

There are some adverse side effects of this change. For one, you can no
longer map to `AnyObject` `[AnyObject]` or `[String: AnyObject]`. This
is because if we made `AnyObject` conform to `DefaultConvertible` we
would be in the same place we were before with the `NSDate` example
compiling, even though it shouldn't. The alternative in the latter 2
cases is to use `NSArray` and `NSDictionary` respectively. After you map
to those, you could then map them back to the Swift types if it was
necessary. Another possible solution for all 3 cases is to create a
transformation that returns these types using `as?`. This way you won't
break the compile time safety for all other types, but you can still get
the types using `AnyObject` back.