### PR TITLE
Add function to create array of RawRepresentables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 - Add `@noescape` to transformation closures
   [Keith Smiley](https://github.com/keith)
   [#60](https://github.com/lyft/mapper/pull/60)
+- Add `from` for arrays of `RawRepresentable`s
+  [Keith Smiley](https://github.com/keith)
+  [#61](https://github.com/lyft/mapper/pull/61)
 
 ## Bug Fixes
 

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ install-tvOS:
 	true
 
 install-lint:
+	brew remove swiftlint --force || true
 	brew install https://raw.githubusercontent.com/Homebrew/homebrew/fffa4b271ba57c7633e8e24cae543a197a9e3e01/Library/Formula/swiftlint.rb
 
 install-carthage:


### PR DESCRIPTION
This enables you to easily take an array in the source data, and get a
strongly typed array of RawRepresentable values. This is heavily
documented to make as obvious as possible the fact that we are
discarding (or replacing) unknown values.

Supersedes https://github.com/lyft/mapper/pull/34