### PR TITLE
Remove force trys from tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
 - Add `from` for arrays of `RawRepresentable`s
   [Keith Smiley](https://github.com/keith)
   [#61](https://github.com/lyft/mapper/pull/61)
+- Remove force trys and casts from tests
+  [Keith Smiley](https://github.com/keith)
+  [#62](https://github.com/lyft/mapper/pull/62)
 
 ## Bug Fixes
 

--- a/Tests/Mapper/ConvertibleValueTests.swift
+++ b/Tests/Mapper/ConvertibleValueTests.swift
@@ -16,31 +16,31 @@ final class ConvertibleValueTests: XCTestCase {
             }
         }
 
-        let test = try! Test(map: Mapper(JSON: ["url": "https://google.com"]))
-        XCTAssertTrue(test.URL.host == "google.com")
+        let test = try? Test(map: Mapper(JSON: ["url": "https://google.com"]))
+        XCTAssertTrue(test?.URL.host == "google.com")
     }
 
     func testOptionalURL() {
         struct Test: Mappable {
             let URL: NSURL?
-            init(map: Mapper) throws {
+            init(map: Mapper) {
                 self.URL = map.optionalFrom("url")
             }
         }
 
-        let test = try! Test(map: Mapper(JSON: ["url": "https://google.com"]))
+        let test = Test(map: Mapper(JSON: ["url": "https://google.com"]))
         XCTAssertTrue(test.URL?.host == "google.com")
     }
 
     func testInvalidURL() {
         struct Test: Mappable {
             let URL: NSURL?
-            init(map: Mapper) throws {
+            init(map: Mapper) {
                 self.URL = map.optionalFrom("url")
             }
         }
 
-        let test = try! Test(map: Mapper(JSON: ["url": "##"]))
+        let test = Test(map: Mapper(JSON: ["url": "##"]))
         XCTAssertNil(test.URL)
     }
 
@@ -52,31 +52,31 @@ final class ConvertibleValueTests: XCTestCase {
             }
         }
 
-        let test = try! Test(map: Mapper(JSON: ["urls": ["https://google.com", "example.com"]]))
-        XCTAssertTrue(test.URLs.count == 2)
+        let test = try? Test(map: Mapper(JSON: ["urls": ["https://google.com", "example.com"]]))
+        XCTAssertTrue(test?.URLs.count == 2)
     }
 
     func testOptionalArrayOfConvertibles() {
         struct Test: Mappable {
             let URLs: [NSURL]?
-            init(map: Mapper) throws {
+            init(map: Mapper) {
                 self.URLs = map.optionalFrom("urls")
             }
         }
 
-        let test = try! Test(map: Mapper(JSON: [:]))
+        let test = try Test(map: Mapper(JSON: [:]))
         XCTAssertNil(test.URLs)
     }
 
     func testExistingOptionalArrayOfConvertibles() {
         struct Test: Mappable {
             let URLs: [NSURL]?
-            init(map: Mapper) throws {
+            init(map: Mapper) {
                 self.URLs = map.optionalFrom("urls")
             }
         }
 
-        let test = try! Test(map: Mapper(JSON: ["urls": ["https://google.com", "example.com"]]))
+        let test = Test(map: Mapper(JSON: ["urls": ["https://google.com", "example.com"]]))
         XCTAssertTrue(test.URLs?.count == 2)
     }
 
@@ -95,36 +95,36 @@ final class ConvertibleValueTests: XCTestCase {
     func testInvalidArrayOfOptionalConvertibles() {
         struct Test: Mappable {
             let URLs: [NSURL]?
-            init(map: Mapper) throws {
+            init(map: Mapper) {
                 self.URLs = map.optionalFrom("urls")
             }
         }
 
-        let test = try! Test(map: Mapper(JSON: ["urls": "not an array"]))
+        let test = Test(map: Mapper(JSON: ["urls": "not an array"]))
         XCTAssertNil(test.URLs)
     }
 
     func testConvertibleArrayOfKeys() {
         struct Test: Mappable {
             let URL: NSURL?
-            init(map: Mapper) throws {
+            init(map: Mapper) {
                 self.URL = map.optionalFrom(["a", "b"])
             }
         }
 
-        let test = try! Test(map: Mapper(JSON: ["a": "##", "b": "example.com"]))
+        let test = Test(map: Mapper(JSON: ["a": "##", "b": "example.com"]))
         XCTAssertTrue(test.URL?.absoluteString == "example.com")
     }
 
     func testConvertibleArrayOfKeysReturnsNil() {
         struct Test: Mappable {
             let URL: NSURL?
-            init(map: Mapper) throws {
+            init(map: Mapper) {
                 self.URL = map.optionalFrom(["a", "b"])
             }
         }
 
-        let test = try! Test(map: Mapper(JSON: [:]))
+        let test = Test(map: Mapper(JSON: [:]))
         XCTAssertNil(test.URL)
     }
 
@@ -137,8 +137,8 @@ final class ConvertibleValueTests: XCTestCase {
             }
         }
 
-        let test = Test.from(["foo": ["key": 1]])!
-        XCTAssertTrue(test.dictionary["key"] == 1)
+        let test = Test.from(["foo": ["key": 1]])
+        XCTAssertTrue(test?.dictionary["key"] == 1)
     }
 
     func testOptionalDictionaryConvertible() {
@@ -150,8 +150,8 @@ final class ConvertibleValueTests: XCTestCase {
             }
         }
 
-        let test = Test.from(["foo": ["key": 1]])!
-        XCTAssertTrue(test.dictionary?["key"] == 1)
+        let test = Test.from(["foo": ["key": 1]])
+        XCTAssertTrue(test?.dictionary?["key"] == 1)
     }
 
     func testDictionaryOfConvertibles() {
@@ -176,8 +176,12 @@ final class ConvertibleValueTests: XCTestCase {
             }
         }
 
-        let test = Test.from(["foo": ["key": "not int"]])!
-        XCTAssertNil(test.dictionary)
+        do {
+            let test = try Test(map: Mapper(JSON: ["foo": ["key": "not int"]]))
+            XCTAssertNil(test.dictionary)
+        } catch {
+            XCTFail("Couldn't create Test")
+        }
     }
 
     func testDictionaryConvertibleSingleInvalid() {

--- a/Tests/Mapper/CustomTransformationTests.swift
+++ b/Tests/Mapper/CustomTransformationTests.swift
@@ -16,8 +16,8 @@ final class CustomTransformationTests: XCTestCase {
             }
         }
 
-        let test = try! Test(map: Mapper(JSON: ["value": 1]))
-        XCTAssertTrue(test.value == 2)
+        let test = try? Test(map: Mapper(JSON: ["value": 1]))
+        XCTAssertTrue(test?.value == 2)
     }
 
     func testCustomTransformationThrows() {
@@ -37,24 +37,24 @@ final class CustomTransformationTests: XCTestCase {
     func testOptionalCustomTransformationExists() {
         struct Test: Mappable {
             let string: String?
-            init(map: Mapper) throws {
+            init(map: Mapper) {
                 string = map.optionalFrom("string", transformation: { $0 as? String })
             }
         }
 
-        let test = try! Test(map: Mapper(JSON: ["string": "hi"]))
+        let test = Test(map: Mapper(JSON: ["string": "hi"]))
         XCTAssertTrue(test.string == "hi")
     }
 
     func testOptionalCustomTransformationDoesNotExist() {
         struct Test: Mappable {
             let string: String?
-            init(map: Mapper) throws {
+            init(map: Mapper) {
                 string = map.optionalFrom("string", transformation: { $0 as? String })
             }
         }
 
-        let test = try! Test(map: Mapper(JSON: [:]))
+        let test = Test(map: Mapper(JSON: [:]))
         XCTAssertNil(test.string)
     }
 
@@ -68,7 +68,11 @@ final class CustomTransformationTests: XCTestCase {
             }
         }
 
-        let test = try! Test(map: Mapper(JSON: [:]))
-        XCTAssertNil(test.string)
+        do {
+            let test = try Test(map: Mapper(JSON: [:]))
+            XCTAssertNil(test.string)
+        } catch {
+            XCTFail("Shouldn't have failed to create Test")
+        }
     }
 }

--- a/Tests/Mapper/MappableValueTests.swift
+++ b/Tests/Mapper/MappableValueTests.swift
@@ -17,8 +17,8 @@ final class MappableValueTests: XCTestCase {
             }
         }
 
-        let test = try! Test(map: Mapper(JSON: ["nest": ["string": "hello"]]))
-        XCTAssertTrue(test.nest.string == "hello")
+        let test = try? Test(map: Mapper(JSON: ["nest": ["string": "hello"]]))
+        XCTAssertTrue(test?.nest.string == "hello")
     }
 
     func testArrayOfMappables() {
@@ -36,23 +36,24 @@ final class MappableValueTests: XCTestCase {
             }
         }
 
-        let test = try! Test(map: Mapper(JSON: ["nests": [["string": "first"], ["string": "second"]]]))
-        XCTAssertTrue(test.nests.count == 2)
+        let test = try? Test(map: Mapper(JSON: ["nests": [["string": "first"], ["string": "second"]]]))
+        XCTAssertTrue(test?.nests.count == 2)
     }
 
     func testOptionalMappable() {
         struct Test: Mappable {
             let nest: Nested?
-            init(map: Mapper) throws {
+            init(map: Mapper) {
                 self.nest = map.optionalFrom("foo")
             }
         }
 
         struct Nested: Mappable {
-            init(map: Mapper) throws {}
+            init(map: Mapper) {}
         }
 
-        let test = try! Test(map: Mapper(JSON: [:]))
+
+        let test = Test(map: Mapper(JSON: [:]))
         XCTAssertNil(test.nest)
     }
 
@@ -78,7 +79,7 @@ final class MappableValueTests: XCTestCase {
     func testValidArrayOfOptionalMappables() {
         struct Test: Mappable {
             let nests: [Nested]?
-            init(map: Mapper) throws {
+            init(map: Mapper) {
                 self.nests = map.optionalFrom("nests")
             }
         }
@@ -90,7 +91,7 @@ final class MappableValueTests: XCTestCase {
             }
         }
 
-        let test = try! Test(map: Mapper(JSON: ["nests": [["string": "first"], ["string": "second"]]]))
+        let test = Test(map: Mapper(JSON: ["nests": [["string": "first"], ["string": "second"]]]))
         XCTAssertTrue(test.nests?.count == 2)
     }
 
@@ -116,7 +117,7 @@ final class MappableValueTests: XCTestCase {
     func testInvalidArrayOfOptionalMappables() {
         struct Test: Mappable {
             let nests: [Nested]?
-            init(map: Mapper) throws {
+            init(map: Mapper) {
                 self.nests = map.optionalFrom("nests")
             }
         }
@@ -128,14 +129,14 @@ final class MappableValueTests: XCTestCase {
             }
         }
 
-        let test = try! Test(map: Mapper(JSON: ["nests": "not an array"]))
+        let test = Test(map: Mapper(JSON: ["nests": "not an array"]))
         XCTAssertNil(test.nests)
     }
 
     func testMappableArrayOfKeys() {
         struct Test: Mappable {
             let nest: Nested?
-            init(map: Mapper) throws {
+            init(map: Mapper) {
                 self.nest = map.optionalFrom(["a", "b"])
             }
         }
@@ -147,14 +148,14 @@ final class MappableValueTests: XCTestCase {
             }
         }
 
-        let test = try! Test(map: Mapper(JSON: ["a": ["foo": "bar"], "b": ["string": "hi"]]))
+        let test = Test(map: Mapper(JSON: ["a": ["foo": "bar"], "b": ["string": "hi"]]))
         XCTAssertTrue(test.nest?.string == "hi")
     }
 
     func testMappableArrayOfKeysReturningNil() {
         struct Test: Mappable {
             let nest: Nested?
-            init(map: Mapper) throws {
+            init(map: Mapper) {
                 self.nest = map.optionalFrom(["a", "b"])
             }
         }
@@ -163,7 +164,10 @@ final class MappableValueTests: XCTestCase {
             init(map: Mapper) throws {}
         }
 
-        let test = Test.from([:])!
-        XCTAssertNil(test.nest)
+        if let test = Test.from([:]) {
+            XCTAssertNil(test.nest)
+        } else {
+            XCTFail("Failed to create Test")
+        }
     }
 }

--- a/Tests/Mapper/NormalValueTests.swift
+++ b/Tests/Mapper/NormalValueTests.swift
@@ -10,8 +10,8 @@ final class NormalValueTests: XCTestCase {
             }
         }
 
-        let test = try! Test(map: Mapper(JSON: ["string": "Hello"]))
-        XCTAssertTrue(test.string == "Hello")
+        let test = try? Test(map: Mapper(JSON: ["string": "Hello"]))
+        XCTAssertTrue(test?.string == "Hello")
     }
 
     func testMappingTimeInterval() {
@@ -22,8 +22,8 @@ final class NormalValueTests: XCTestCase {
             }
         }
 
-        let test = try! Test(map: Mapper(JSON: ["time": 123]))
-        XCTAssertTrue(test.string == 123)
+        let test = try? Test(map: Mapper(JSON: ["time": 123]))
+        XCTAssertTrue(test?.string == 123)
     }
 
     func testMappingMissingKey() {
@@ -41,12 +41,12 @@ final class NormalValueTests: XCTestCase {
     func testFallbackMissingKey() {
         struct Test: Mappable {
             let string: String
-            init(map: Mapper) throws {
+            init(map: Mapper) {
                 self.string = map.optionalFrom("foo") ?? "Hello"
             }
         }
 
-        let test = try! Test(map: Mapper(JSON: [:]))
+        let test = Test(map: Mapper(JSON: [:]))
         XCTAssertTrue(test.string == "Hello")
     }
 
@@ -58,8 +58,8 @@ final class NormalValueTests: XCTestCase {
             }
         }
 
-        let test = try! Test(map: Mapper(JSON: ["strings": ["first", "second"]]))
-        XCTAssertTrue(test.strings.count == 2)
+        let test = try? Test(map: Mapper(JSON: ["strings": ["first", "second"]]))
+        XCTAssertTrue(test?.strings.count == 2)
     }
 
     func testEmptyStringJSON() {
@@ -71,8 +71,9 @@ final class NormalValueTests: XCTestCase {
         }
 
         let JSON = ["a": "b", "c": "d"]
-        let test = try! Test(map: Mapper(JSON: JSON))
-        XCTAssertTrue((test.JSON as! [String: String]) == JSON)
+        let test = try? Test(map: Mapper(JSON: JSON))
+        let parsedJSON = test?.JSON as? [String: String] ?? [:]
+        XCTAssertTrue(parsedJSON == JSON)
     }
 
     func testKeyPath() {
@@ -83,8 +84,8 @@ final class NormalValueTests: XCTestCase {
             }
         }
 
-        let test = try! Test(map: Mapper(JSON: ["foo": ["bar": "baz"]]))
-        XCTAssertTrue(test.string == "baz")
+        let test = try? Test(map: Mapper(JSON: ["foo": ["bar": "baz"]]))
+        XCTAssertTrue(test?.string == "baz")
     }
 
     func testPartiallyInvalidArrayOfValues() {

--- a/Tests/Mapper/OptionalValueTests.swift
+++ b/Tests/Mapper/OptionalValueTests.swift
@@ -5,49 +5,49 @@ final class OptionalValueTests: XCTestCase {
     func testMappingStringToClass() {
         final class Test: Mappable {
             let string: String
-            required init(map: Mapper) throws {
+            required init(map: Mapper) {
                 self.string = map.optionalFrom("string") ?? ""
             }
         }
 
-        let test = try! Test(map: Mapper(JSON: ["string": "Hello"]))
+        let test = Test(map: Mapper(JSON: ["string": "Hello"]))
         XCTAssertTrue(test.string == "Hello")
     }
 
     func testMappingOptionalValue() {
         struct Test: Mappable {
             let string: String?
-            init(map: Mapper) throws {
+            init(map: Mapper) {
                 self.string = map.optionalFrom("foo")
             }
         }
 
-        let test = try! Test(map: Mapper(JSON: [:]))
+        let test = Test(map: Mapper(JSON: [:]))
         XCTAssertNil(test.string)
     }
 
     func testMappingOptionalArray() {
         struct Test: Mappable {
             let string: [String]?
-            init(map: Mapper) throws {
+            init(map: Mapper) {
                 self.string = map.optionalFrom("foo")
             }
         }
 
-        let test = try! Test(map: Mapper(JSON: [:]))
+        let test = Test(map: Mapper(JSON: [:]))
         XCTAssertNil(test.string)
     }
 
     func testMappingOptionalExistingArray() {
         struct Test: Mappable {
             let strings: [String]?
-            init(map: Mapper) throws {
+            init(map: Mapper) {
                 self.strings = map.optionalFrom("strings")
             }
         }
 
-        let test = try! Test(map: Mapper(JSON: ["strings": ["first", "second"]]))
-        XCTAssertTrue(test.strings!.count == 2)
+        let test = Test(map: Mapper(JSON: ["strings": ["first", "second"]]))
+        XCTAssertTrue(test.strings?.count == 2)
     }
 
     func testMappingArrayOfOptionalFieldsPicksNonNil() {
@@ -62,19 +62,19 @@ final class OptionalValueTests: XCTestCase {
             }
         }
 
-        let test = Test.from(["b": "foo"])!
-        XCTAssertTrue(test.string == "foo")
+        let test = Test.from(["b": "foo"])
+        XCTAssertTrue(test?.string == "foo")
     }
 
     func testMappingArrayOfOptionalFieldsReturnsNil() {
         struct Test: Mappable {
             let string: String?
-            init(map: Mapper) throws {
+            init(map: Mapper) {
                 self.string = map.optionalFrom(["a", "b"])
             }
         }
 
-        let test = Test.from([:])!
+        let test = Test(map: Mapper(JSON: [:]))
         XCTAssertNil(test.string)
     }
 }

--- a/Tests/Mapper/RawRepresentibleValueTests.swift
+++ b/Tests/Mapper/RawRepresentibleValueTests.swift
@@ -14,8 +14,8 @@ final class RawRepresentibleValueTests: XCTestCase {
             case Hearts = "hearts"
         }
 
-        let test = try! Test(map: Mapper(JSON: ["suit": "hearts"]))
-        XCTAssertTrue(test.suit == .Hearts)
+        let test = try? Test(map: Mapper(JSON: ["suit": "hearts"]))
+        XCTAssertTrue(test?.suit == .Hearts)
     }
 
     func testRawRepresentableNumber() {
@@ -30,8 +30,8 @@ final class RawRepresentibleValueTests: XCTestCase {
             case First = 1
         }
 
-        let test = try! Test(map: Mapper(JSON: ["value": 1]))
-        XCTAssertTrue(test.value == .First)
+        let test = try? Test(map: Mapper(JSON: ["value": 1]))
+        XCTAssertTrue(test?.value == .First)
     }
 
     func testMissingRawRepresentableNumber() {
@@ -53,7 +53,7 @@ final class RawRepresentibleValueTests: XCTestCase {
     func testOptionalRawRepresentable() {
         struct Test: Mappable {
             let value: Value?
-            init(map: Mapper) throws {
+            init(map: Mapper) {
                 self.value = map.optionalFrom("value")
             }
         }
@@ -62,14 +62,14 @@ final class RawRepresentibleValueTests: XCTestCase {
             case First = 1
         }
 
-        let test = try! Test(map: Mapper(JSON: [:]))
+        let test = Test(map: Mapper(JSON: [:]))
         XCTAssertNil(test.value)
     }
 
     func testExistingOptionalRawRepresentable() {
         struct Test: Mappable {
             let value: Value?
-            init(map: Mapper) throws {
+            init(map: Mapper) {
                 self.value = map.optionalFrom("value")
             }
         }
@@ -78,14 +78,14 @@ final class RawRepresentibleValueTests: XCTestCase {
             case First = 1
         }
 
-        let test = try! Test(map: Mapper(JSON: ["value": 1]))
+        let test = Test(map: Mapper(JSON: ["value": 1]))
         XCTAssertTrue(test.value == .First)
     }
 
     func testRawRepresentableTypeMismatch() {
         struct Test: Mappable {
             let value: Value?
-            init(map: Mapper) throws {
+            init(map: Mapper) {
                 self.value = map.optionalFrom("value")
             }
         }
@@ -94,14 +94,14 @@ final class RawRepresentibleValueTests: XCTestCase {
             case First = 1
         }
 
-        let test = try! Test(map: Mapper(JSON: ["value": "not an int"]))
+        let test = Test(map: Mapper(JSON: ["value": "not an int"]))
         XCTAssertNil(test.value)
     }
 
     func testRawRepresentableArrayOfKeys() {
         struct Test: Mappable {
             let value: Value?
-            init(map: Mapper) throws {
+            init(map: Mapper) {
                 self.value = map.optionalFrom(["a", "b"])
             }
         }
@@ -110,14 +110,14 @@ final class RawRepresentibleValueTests: XCTestCase {
             case First = "hi"
         }
 
-        let test = try! Test(map: Mapper(JSON: ["a": "nope", "b": "hi"]))
+        let test = Test(map: Mapper(JSON: ["a": "nope", "b": "hi"]))
         XCTAssertTrue(test.value == .First)
     }
 
     func testRawRepresentableArrayOfKeysReturningNil() {
         struct Test: Mappable {
             let value: Value?
-            init(map: Mapper) throws {
+            init(map: Mapper) {
                 self.value = map.optionalFrom(["a", "b"])
             }
         }
@@ -126,7 +126,7 @@ final class RawRepresentibleValueTests: XCTestCase {
             case First = "hi"
         }
 
-        let test = try! Test(map: Mapper(JSON: [:]))
+        let test = Test(map: Mapper(JSON: [:]))
         XCTAssertNil(test.value)
     }
 

--- a/Tests/Mapper/TransformTests.swift
+++ b/Tests/Mapper/TransformTests.swift
@@ -44,11 +44,11 @@ final class TransformTests: XCTestCase {
                 ],
             ]
         ]
-        let test = Test.from(JSON)!
 
-        XCTAssertTrue(test.dictionary.count == 2)
-        XCTAssertTrue(test.dictionary["hi"] == Example(key: "hi", value: 1))
-        XCTAssertTrue(test.dictionary["bye"] == Example(key: "bye", value: 2))
+        let test = Test.from(JSON)
+        XCTAssertTrue(test?.dictionary.count == 2)
+        XCTAssertTrue(test?.dictionary["hi"] == Example(key: "hi", value: 1))
+        XCTAssertTrue(test?.dictionary["bye"] == Example(key: "bye", value: 2))
     }
 
     func testToDictionaryInvalid() {


### PR DESCRIPTION
When working on large changes to Mapper, these force trys and force
casts would often end up with annoying test failures. Instead now we
handle the optionals, or the error handling as needed. We also lean a
little bit on the fact that we can remove `throws` from initializers of
`Mappable` and it still works since that isn't part of the function
signature.