### PR TITLE
Replace valueForKeyPath with custom function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,9 @@
 
 ## Bug Fixes
 
-- None
+- Fix `valueForKeyPath` crash by removing it.
+  [Keith Smiley](https://github.com/keith)
+  [#63](https://github.com/lyft/mapper/pull/63)
 
 # 2.1.0
 

--- a/Mapper.xcodeproj/project.pbxproj
+++ b/Mapper.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		C201748E1BD5509D00E4FE18 /* Mapper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C20174831BD5509D00E4FE18 /* Mapper.framework */; };
 		C20586EC1CDEAD9900658A67 /* DefaultConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20586EB1CDEAD9900658A67 /* DefaultConvertible.swift */; };
+		C2B2A5761D3DE82700F7E7DE /* NSDictionary+Safety.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2B2A5751D3DE82700F7E7DE /* NSDictionary+Safety.swift */; };
 		C2B977A91CCD7AD800FDA451 /* ErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2B977A71CCD7AB200FDA451 /* ErrorTests.swift */; };
 		C2C036FA1C2B1A0B003FB853 /* Convertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2C036F31C2B1A0B003FB853 /* Convertible.swift */; };
 		C2C036FB1C2B1A0B003FB853 /* MapperError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2C036F41C2B1A0B003FB853 /* MapperError.swift */; };
@@ -41,6 +42,7 @@
 		C20174831BD5509D00E4FE18 /* Mapper.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Mapper.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C201748D1BD5509D00E4FE18 /* MapperTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MapperTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C20586EB1CDEAD9900658A67 /* DefaultConvertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultConvertible.swift; sourceTree = "<group>"; };
+		C2B2A5751D3DE82700F7E7DE /* NSDictionary+Safety.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSDictionary+Safety.swift"; sourceTree = "<group>"; };
 		C2B977A71CCD7AB200FDA451 /* ErrorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorTests.swift; sourceTree = "<group>"; };
 		C2C036D11C2B180D003FB853 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C2C036D41C2B180D003FB853 /* UniversalFramework_Base.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = UniversalFramework_Base.xcconfig; sourceTree = "<group>"; };
@@ -121,6 +123,7 @@
 				C2C036F51C2B1A0B003FB853 /* Mappable.swift */,
 				C2C036F61C2B1A0B003FB853 /* Mapper.swift */,
 				C2C036F41C2B1A0B003FB853 /* MapperError.swift */,
+				C2B2A5751D3DE82700F7E7DE /* NSDictionary+Safety.swift */,
 				C2C036F71C2B1A0B003FB853 /* NSURL+Convertible.swift */,
 				C2C036F91C2B1A0B003FB853 /* Transform.swift */,
 				C2C036F81C2B1A0B003FB853 /* Transform+Dictionary.swift */,
@@ -230,6 +233,7 @@
 			files = (
 				C2C036FF1C2B1A0B003FB853 /* Transform+Dictionary.swift in Sources */,
 				C2C036FE1C2B1A0B003FB853 /* NSURL+Convertible.swift in Sources */,
+				C2B2A5761D3DE82700F7E7DE /* NSDictionary+Safety.swift in Sources */,
 				C2C036FD1C2B1A0B003FB853 /* Mapper.swift in Sources */,
 				C2C037001C2B1A0B003FB853 /* Transform.swift in Sources */,
 				C2C036FB1C2B1A0B003FB853 /* MapperError.swift in Sources */,

--- a/Sources/Mapper.swift
+++ b/Sources/Mapper.swift
@@ -419,7 +419,7 @@ public struct Mapper {
      - returns: The object for the given field
      */
     private func JSONFromField(field: String) throws -> AnyObject {
-        if let value = field.isEmpty ? self.JSON : self.JSON.valueForKeyPath(field) {
+        if let value = field.isEmpty ? self.JSON : self.JSON.safeValueForKeyPath(field) {
             return value
         }
 

--- a/Sources/NSDictionary+Safety.swift
+++ b/Sources/NSDictionary+Safety.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+extension NSDictionary {
+    func safeValueForKeyPath(keyPath: String) -> AnyObject? {
+        var object: AnyObject? = self
+        var keys = keyPath.characters.split(".").map(String.init)
+
+        while keys.count > 0, let currentObject = object {
+            let key = keys.removeAtIndex(0)
+            object = (currentObject as? NSDictionary)?[key]
+        }
+
+        return object
+    }
+}

--- a/Tests/Mapper/NormalValueTests.swift
+++ b/Tests/Mapper/NormalValueTests.swift
@@ -111,4 +111,16 @@ final class NormalValueTests: XCTestCase {
         let test = try? Test(map: Mapper(JSON: ["string": "hi"]))
         XCTAssertEqual(test?.string, "hi")
     }
+
+    func testNestedKeysWithInvalidType() {
+        struct Test: Mappable {
+            let string: String
+            init(map: Mapper) throws {
+                try self.string = map.from("user.phone")
+            }
+        }
+
+        let test = try? Test(map: Mapper(JSON: ["user": "not dictionary"]))
+        XCTAssertNil(test)
+    }
 }


### PR DESCRIPTION
Currently `valueForKeyPath:` is a little more generic than we need it to
be, and depending on the scenario this can cause an `NSException` to be
thrown, which cannot be caught from Swift.

Here is a case that will fail:

```swift
let dictionary = ["user": "not dictionary"] as NSDictionary
dictionary.valueForKeyPath("user.phone") // Crashes
```

But really in our use case, we don't care about non-dictionary objects
to be key value coding compliant for the key we're interested in.
Luckily, if the key is nil, it will not crash:

```swift
let dictionary = [:] as NSDictionary
dictionary.valueForKeyPath("user.phone") // Returns nil
```

To fix this, since `valueForKey` also crashes in these cases, we will
instead just treat everything as an `NSDictionary` and fetch the keys
accordingly.