### PR TITLE
Fix transformation nullability

### DIFF
--- a/Sources/Mapper.swift
+++ b/Sources/Mapper.swift
@@ -389,8 +389,8 @@ public struct Mapper {
      - returns: The value of type T for the given field
      */
     @warn_unused_result
-    public func from<T>(field: String, @noescape transformation: AnyObject throws -> T) throws -> T {
-        return try transformation(try self.JSONFromField(field))
+    public func from<T>(field: String, @noescape transformation: AnyObject? throws -> T) throws -> T {
+        return try transformation(try? self.JSONFromField(field))
     }
 
     /**

--- a/Sources/Mapper.swift
+++ b/Sources/Mapper.swift
@@ -389,7 +389,7 @@ public struct Mapper {
      - returns: The value of type T for the given field
      */
     @warn_unused_result
-    public func from<T>(field: String, @noescape transformation: AnyObject? throws -> T) throws -> T {
+    public func from<T>(field: String, @noescape transformation: AnyObject throws -> T) throws -> T {
         return try transformation(try self.JSONFromField(field))
     }
 


### PR DESCRIPTION
Noticed this when I was upgrading to `3.0.0` recently, It makes consumers have either force unwrap the transformation argument or guard it and do the same code that `JSONFromField(field)` does, which isn't nice.