### PR TITLE
Feature/nil convertible

### DIFF
--- a/Mapper.xcodeproj/project.pbxproj
+++ b/Mapper.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		75C28C551D6231D200C6D0BA /* NilConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75C28C541D6231D200C6D0BA /* NilConvertible.swift */; };
 		C201748E1BD5509D00E4FE18 /* Mapper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C20174831BD5509D00E4FE18 /* Mapper.framework */; };
 		C20586EC1CDEAD9900658A67 /* DefaultConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20586EB1CDEAD9900658A67 /* DefaultConvertible.swift */; };
 		C2B2A5761D3DE82700F7E7DE /* NSDictionary+Safety.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2B2A5751D3DE82700F7E7DE /* NSDictionary+Safety.swift */; };
@@ -39,6 +40,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		75C28C541D6231D200C6D0BA /* NilConvertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NilConvertible.swift; sourceTree = "<group>"; };
 		C20174831BD5509D00E4FE18 /* Mapper.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Mapper.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C201748D1BD5509D00E4FE18 /* MapperTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MapperTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C20586EB1CDEAD9900658A67 /* DefaultConvertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultConvertible.swift; sourceTree = "<group>"; };
@@ -118,6 +120,7 @@
 		C2C036F21C2B1A0B003FB853 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				75C28C541D6231D200C6D0BA /* NilConvertible.swift */,
 				C2C036F31C2B1A0B003FB853 /* Convertible.swift */,
 				C20586EB1CDEAD9900658A67 /* DefaultConvertible.swift */,
 				C2C036F51C2B1A0B003FB853 /* Mappable.swift */,
@@ -236,6 +239,7 @@
 				C2B2A5761D3DE82700F7E7DE /* NSDictionary+Safety.swift in Sources */,
 				C2C036FD1C2B1A0B003FB853 /* Mapper.swift in Sources */,
 				C2C037001C2B1A0B003FB853 /* Transform.swift in Sources */,
+				75C28C551D6231D200C6D0BA /* NilConvertible.swift in Sources */,
 				C2C036FB1C2B1A0B003FB853 /* MapperError.swift in Sources */,
 				C20586EC1CDEAD9900658A67 /* DefaultConvertible.swift in Sources */,
 				C2C036FC1C2B1A0B003FB853 /* Mappable.swift in Sources */,

--- a/Sources/Convertible.swift
+++ b/Sources/Convertible.swift
@@ -10,7 +10,7 @@
 
  // Convertible implementation for custom logic to create `CLLocationCoordinate2D`s from dictionaries
  extension CLLocationCoordinate2D: Convertible {
-     public static func fromMap(value: AnyObject?) throws -> CLLocationCoordinate2D {
+     public static func fromMap(value: AnyObject) throws -> CLLocationCoordinate2D {
          guard let location = value as? NSDictionary,
              let latitude = (location["lat"] ?? location["latitude"]) as? Double,
              let longitude = (location["lng"] ?? location["longitude"]) as? Double else
@@ -40,5 +40,5 @@ public protocol Convertible {
      - returns: The successfully created value from the given input
      */
     @warn_unused_result
-    static func fromMap(value: AnyObject?) throws -> ConvertedType
+    static func fromMap(value: AnyObject) throws -> ConvertedType
 }

--- a/Sources/DefaultConvertible.swift
+++ b/Sources/DefaultConvertible.swift
@@ -11,7 +11,7 @@
 public protocol DefaultConvertible: Convertible {}
 
 extension DefaultConvertible {
-    public static func fromMap(value: AnyObject?) throws -> ConvertedType {
+    public static func fromMap(value: AnyObject) throws -> ConvertedType {
         if let object = value as? ConvertedType {
             return object
         }

--- a/Sources/Mapper.swift
+++ b/Sources/Mapper.swift
@@ -392,25 +392,6 @@ public struct Mapper {
         return try T.fromMap(try? self.JSONFromField(field))
     }
     
-    /**
-     Get a NilConvertible value from a field in the source data
-     
-     This transparently converts your types that conform to NilConvertible to properties on the Mappable type
-     
-     - parameter field: The field to retrieve from the source data, can be an empty string to return the
-     entire data set
-     
-     - throws: Any error produced by the custom NilConvertible implementation
-     
-     - note: This function is necessary because swift does not coerce the from that returns T to an optional
-     
-     - returns: The value for the given field, if it can be converted to the expected type Optional<T>
-     */
-    @warn_unused_result
-    public func from<T: NilConvertible where T == T.ConvertedType>(field: String) throws -> T? {
-        return try T.fromMap(try? self.JSONFromField(field))
-    }
-    
     // MARK: - Custom Transformation
 
     /**

--- a/Sources/Mapper.swift
+++ b/Sources/Mapper.swift
@@ -373,6 +373,44 @@ public struct Mapper {
         return nil
     }
 
+    // MARK: - NilConvertible
+    
+    /**
+     Get a NilConvertible value from a field in the source data
+     
+     This transparently converts your types that conform to NilConvertible to properties on the Mappable type
+     
+     - parameter field: The field to retrieve from the source data, can be an empty string to return the
+     entire data set
+     
+     - throws: Any error produced by the custom NilConvertible implementation
+     
+     - returns: The value for the given field, if it can be converted to the expected type T
+     */
+    @warn_unused_result
+    public func from<T: NilConvertible where T == T.ConvertedType>(field: String) throws -> T {
+        return try T.fromMap(try? self.JSONFromField(field))
+    }
+    
+    /**
+     Get a NilConvertible value from a field in the source data
+     
+     This transparently converts your types that conform to NilConvertible to properties on the Mappable type
+     
+     - parameter field: The field to retrieve from the source data, can be an empty string to return the
+     entire data set
+     
+     - throws: Any error produced by the custom NilConvertible implementation
+     
+     - note: This function is necessary because swift does not coerce the from that returns T to an optional
+     
+     - returns: The value for the given field, if it can be converted to the expected type Optional<T>
+     */
+    @warn_unused_result
+    public func from<T: NilConvertible where T == T.ConvertedType>(field: String) throws -> T? {
+        return try T.fromMap(try? self.JSONFromField(field))
+    }
+    
     // MARK: - Custom Transformation
 
     /**

--- a/Sources/Mapper.swift
+++ b/Sources/Mapper.swift
@@ -389,7 +389,7 @@ public struct Mapper {
      - returns: The value of type T for the given field
      */
     @warn_unused_result
-    public func from<T>(field: String, @noescape transformation: AnyObject? throws -> T) throws -> T {
+    public func from<T>(field: String, @noescape transformation: AnyObject throws -> T) throws -> T {
         return try transformation(try self.JSONFromField(field))
     }
 

--- a/Sources/NSURL+Convertible.swift
+++ b/Sources/NSURL+Convertible.swift
@@ -15,7 +15,7 @@ extension NSURL: Convertible {
      - returns: The created NSURL
      */
     @warn_unused_result
-    public static func fromMap(value: AnyObject?) throws -> NSURL {
+    public static func fromMap(value: AnyObject) throws -> NSURL {
         guard let string = value as? String else {
             throw MapperError.ConvertibleError(value: value, type: String.self)
         }

--- a/Sources/NilConvertible.swift
+++ b/Sources/NilConvertible.swift
@@ -1,0 +1,20 @@
+public protocol NilConvertible {
+    /// This typealias allows us to enforce the returned value is of type Self, without requiring
+    /// implementations to return a value using `self.init`
+    associatedtype ConvertedType = Self
+    
+    /**
+     `fromMap` returns the expected value based off the provided input, this allows you to attempt
+     to cast the value to anything you'd like, and perform any manipulation on it (don't use this as a
+     conversion mechanism, instead see Transform)
+     
+     - parameter value: Any value (probably from the data source's value for the given field) to create
+     the expected object with
+     
+     - throws: Any error from your custom implementation, MapperError.ConvertibleError is recommended
+     
+     - returns: The successfully created value from the given input
+     */
+    @warn_unused_result
+    static func fromMap(value: AnyObject?) throws -> ConvertedType
+}

--- a/Sources/NilConvertible.swift
+++ b/Sources/NilConvertible.swift
@@ -5,8 +5,9 @@ public protocol NilConvertible {
     
     /**
      `fromMap` returns the expected value based off the provided input, this allows you to attempt
-     to cast the value to anything you'd like, and perform any manipulation on it (don't use this as a
-     conversion mechanism, instead see Transform)
+     to cast the value to anything you'd like and perform any manipulation on it (don't use this as a
+     conversion mechanism, instead see Transform). NilConvertible differs from Convertible in that it
+     also lets you handle the nil case yourself.
      
      - parameter value: Any value (probably from the data source's value for the given field) to create
      the expected object with

--- a/Tests/Mapper/ConvertibleValueTests.swift
+++ b/Tests/Mapper/ConvertibleValueTests.swift
@@ -7,6 +7,18 @@ private struct Foo: Convertible {
     }
 }
 
+private enum NilConvertibleEnum: NilConvertible {
+    case NoValue
+    case SomeValue
+    
+    static func fromMap(value: AnyObject?) throws -> NilConvertibleEnum {
+        switch value {
+            case .None: return .NoValue
+            case .Some(_): return .SomeValue
+        }
+    }
+}
+
 final class ConvertibleValueTests: XCTestCase {
     func testCreatingURL() {
         struct Test: Mappable {
@@ -208,5 +220,31 @@ final class ConvertibleValueTests: XCTestCase {
 
         let test = Test.from(["foo": "not a dictionary"])
         XCTAssertNil(test)
+    }
+    
+    func testNilConvertibleWithNilField() {
+        struct Test: Mappable {
+            let enumField: NilConvertibleEnum
+            
+            init(map: Mapper) throws {
+                try self.enumField = map.from("foo")
+            }
+        }
+        
+        let test = Test.from([:])
+        XCTAssert(test?.enumField == .NoValue)
+    }
+    
+    func testNilConvertibleWithNonNilField() {
+        struct Test: Mappable {
+            let enumField: NilConvertibleEnum
+            
+            init(map: Mapper) throws {
+                try self.enumField = map.from("foo")
+            }
+        }
+        
+        let test = Test.from(["foo" : "bar"])
+        XCTAssert(test?.enumField == .SomeValue)
     }
 }

--- a/Tests/Mapper/ConvertibleValueTests.swift
+++ b/Tests/Mapper/ConvertibleValueTests.swift
@@ -2,7 +2,7 @@ import Mapper
 import XCTest
 
 private struct Foo: Convertible {
-    static func fromMap(value: AnyObject?) throws -> Foo {
+    static func fromMap(value: AnyObject) throws -> Foo {
         return Foo()
     }
 }


### PR DESCRIPTION
So we talked about this in #65. We have some `Mappable` structs which have fields that the presence of determines functionality, so we wish to be able to convert nil into something, which cannot be done without defaulting at the callsite which isn't very nice.

I've created a `NilConvertible` protocol to facilitate this need. I realise it's close to the `NilLiteralConvertible` protocol in the swift standard library but I believe it is the best name to use for this.