### PR TITLE
Swift 3.0 Beta Seed 6

### DIFF
--- a/Sources/Mapper.swift
+++ b/Sources/Mapper.swift
@@ -95,8 +95,8 @@ public struct Mapper {
 
      - returns: An array of the RawRepresentable value, with all nils removed
      */
-    public func from<T: RawRepresentable where T.RawValue: Convertible,
-        T.RawValue == T.RawValue.ConvertedType>(_ field: String, defaultValue: T? = nil) throws -> [T]
+    public func from<T: RawRepresentable>(_ field: String, defaultValue: T? = nil) throws -> [T] where T.RawValue: Convertible,
+        T.RawValue == T.RawValue.ConvertedType
     {
         let value = try self.JSONFromField(field)
         guard let array = value as? [AnyObject] else {
@@ -218,7 +218,7 @@ public struct Mapper {
 
      - returns: The value for the given field, if it can be converted to the expected type T
      */
-    public func from<T: Convertible where T == T.ConvertedType>(_ field: String) throws -> T {
+    public func from<T: Convertible>(_ field: String) throws -> T where T == T.ConvertedType {
         return try self.from(field, transformation: T.fromMap)
     }
 
@@ -236,7 +236,7 @@ public struct Mapper {
 
      - returns: The value for the given field, if it can be converted to the expected type Optional<T>
      */
-    public func from<T: Convertible where T == T.ConvertedType>(_ field: String) throws -> T? {
+    public func from<T: Convertible>(_ field: String) throws -> T? where T == T.ConvertedType {
         return try self.from(field, transformation: T.fromMap)
     }
 
@@ -254,7 +254,7 @@ public struct Mapper {
 
      - returns: The value for the given field, if it can be converted to the expected type [T]
      */
-    public func from<T: Convertible where T == T.ConvertedType>(_ field: String) throws -> [T] {
+    public func from<T: Convertible>(_ field: String) throws -> [T] where T == T.ConvertedType {
         let value = try self.JSONFromField(field)
         if let JSON = value as? [AnyObject] {
             return try JSON.map(T.fromMap)
@@ -273,7 +273,7 @@ public struct Mapper {
 
      - returns: The value for the given field, if it can be converted to the expected type T otherwise nil
      */
-    public func optionalFrom<T: Convertible where T == T.ConvertedType>(_ field: String) -> T? {
+    public func optionalFrom<T: Convertible>(_ field: String) -> T? where T == T.ConvertedType {
         return try? self.from(field, transformation: T.fromMap)
     }
 
@@ -287,7 +287,7 @@ public struct Mapper {
 
      - returns: The value for the given field, if it can be converted to the expected type [T]
      */
-    public func optionalFrom<T: Convertible where T == T.ConvertedType>(_ field: String) -> [T]? {
+    public func optionalFrom<T: Convertible>(_ field: String) -> [T]? where T == T.ConvertedType {
         return try? self.from(field)
     }
 
@@ -304,18 +304,26 @@ public struct Mapper {
 
      - returns: A dictionary where the keys and values are created using their convertible implementations
      */
-    public func from<U: Convertible, T: Convertible
-        where U == U.ConvertedType, T == T.ConvertedType>(_ field: String) throws -> [U: T]
+    public func from<U: Convertible, T: Convertible>(_ field: String) throws -> [U: T]
+        where U == U.ConvertedType, T == T.ConvertedType
     {
         let object = try self.JSONFromField(field)
-        guard let data = object as? NSDictionary else {
+
+        var result = [U: T]()
+        if let data = object as? NSDictionary {
+            for (key, value) in data {
+                result[try U.fromMap(key as AnyObject?)] = try T.fromMap(value as AnyObject?)
+            }
+        }
+        else if let data = object as? [AnyHashable: Any] {
+            for (key, value) in data {
+                result[try U.fromMap(key as AnyObject?)] = try T.fromMap(value as AnyObject?)
+            }
+        }
+        else {
             throw MapperError.typeMismatchError(field: field, value: object, type: NSDictionary.self)
         }
 
-        var result = [U: T]()
-        for (key, value) in data {
-            result[try U.fromMap(key)] = try T.fromMap(value)
-        }
 
         return result
     }
@@ -331,8 +339,8 @@ public struct Mapper {
      - returns: A dictionary where the keys and values are created using their convertible implementations or
                 nil if anything throws
      */
-    public func optionalFrom<U: Convertible, T: Convertible
-        where U == U.ConvertedType, T == T.ConvertedType>(_ field: String) -> [U: T]?
+    public func optionalFrom<U: Convertible, T: Convertible>(_ field: String) -> [U: T]?
+        where U == U.ConvertedType, T == T.ConvertedType
     {
         return try? self.from(field)
     }
@@ -345,7 +353,7 @@ public struct Mapper {
 
      - returns: The first non-nil value to be produced from the array of fields, or nil if none exist
      */
-    public func optionalFrom<T: Convertible where T == T.ConvertedType>(_ fields: [String]) -> T? {
+    public func optionalFrom<T: Convertible>(_ fields: [String]) -> T? where T == T.ConvertedType {
         for field in fields {
             if let value: T = try? self.from(field) {
                 return value
@@ -370,8 +378,10 @@ public struct Mapper {
 
      - returns: The value of type T for the given field
      */
-    public func from<T>(_ field: String, transformation: @noescape (AnyObject?) throws -> T) throws -> T {
-        return try transformation(try self.JSONFromField(field))
+    public func from<T>(_ field: String, transformation: (AnyObject?) throws -> T) throws -> T {
+        let json = try self.JSONFromField(field)
+        
+        return try transformation(json)
     }
 
     /**
@@ -384,7 +394,7 @@ public struct Mapper {
      - returns: The value of type T for the given field, if the transformation function doesn't throw
                 otherwise nil
      */
-    public func optionalFrom<T>(_ field: String, transformation: @noescape (AnyObject?) throws -> T?) -> T? {
+    public func optionalFrom<T>(_ field: String, transformation: (AnyObject?) throws -> T?) -> T? {
         return (try? transformation(try? self.JSONFromField(field))).flatMap { $0 }
     }
 
@@ -402,8 +412,9 @@ public struct Mapper {
      - returns: The object for the given field
      */
     private func JSONFromField(_ field: String) throws -> AnyObject {
-        if let value = field.isEmpty ? self.JSON : self.JSON.safeValue(forKeyPath: field) {
-            return value
+        let optionalValue: Any? = field.isEmpty ? self.JSON : self.JSON.safeValue(forKeyPath: field)
+        if let value = optionalValue {
+            return value as AnyObject
         }
 
         throw MapperError.missingFieldError(field: field)

--- a/Sources/MapperError.swift
+++ b/Sources/MapperError.swift
@@ -10,7 +10,7 @@
  - MissingFieldError:    An error thrown when the desired key isn't in the JSON
  - TypeMismatchError:    Thrown when the desired key exists in the JSON, but does not match the expected type
  */
-public enum MapperError: ErrorProtocol {
+public enum MapperError: Error {
     case convertibleError(value: AnyObject?, type: Any.Type)
     case customError(field: String?, message: String)
     case invalidRawValueError(field: String, value: Any, type: Any.Type)

--- a/Sources/NSDictionary+Safety.swift
+++ b/Sources/NSDictionary+Safety.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 extension NSDictionary {
-    func safeValue(forKeyPath keyPath: String) -> AnyObject? {
-        var object: AnyObject? = self
+    func safeValue(forKeyPath keyPath: String) -> Any? {
+        var object: Any? = self
         var keys = keyPath.characters.split(separator: ".").map(String.init)
 
         while keys.count > 0, let currentObject = object {

--- a/Sources/Transform+Dictionary.swift
+++ b/Sources/Transform+Dictionary.swift
@@ -45,8 +45,8 @@ public extension Transform {
      - returns: A dictionary of [U: T] where the keys U are produced from the passed `key` function and the
                 values T are the objects
      */
-    public static func toDictionary<T, U where T: Mappable, U: Hashable>(key getKey: (T) -> U) ->
-        (object: AnyObject?) throws -> [U: T]
+    public static func toDictionary<T, U>(key getKey: @escaping (T) -> U) ->
+        (_ object: AnyObject?) throws -> [U: T] where T: Mappable, U: Hashable
     {
         return { object in
             guard let objects = object as? [NSDictionary] else {

--- a/Tests/Mapper/ConvertibleValueTests.swift
+++ b/Tests/Mapper/ConvertibleValueTests.swift
@@ -137,7 +137,8 @@ final class ConvertibleValueTests: XCTestCase {
             }
         }
 
-        let test = Test.from(["foo": ["key": 1]])
+        let JSON = ["foo": ["key": 1]]
+        let test = Test.from(JSON as NSDictionary)
         XCTAssertTrue(test?.dictionary["key"] == 1)
     }
 
@@ -164,7 +165,7 @@ final class ConvertibleValueTests: XCTestCase {
         }
 
         let test = Test.from(["foo": ["key": "value"]])
-        XCTAssertTrue(test?.dictionary.count > 0)
+        XCTAssertGreaterThan(test?.dictionary.count ?? 0, 0)
     }
 
     func testOptionalDictionaryConvertibleNil() {

--- a/Tests/Mapper/ErrorTests.swift
+++ b/Tests/Mapper/ErrorTests.swift
@@ -59,7 +59,7 @@ final class ErrorTests: XCTestCase {
         } catch MapperError.missingFieldError(let field) {
             XCTAssert(field == "string")
         } catch {
-            XCTFail()
+            XCTFail("Expected only missing field error, got \(error)")
         }
     }
 

--- a/Tests/Mapper/NormalValueTests.swift
+++ b/Tests/Mapper/NormalValueTests.swift
@@ -71,7 +71,7 @@ final class NormalValueTests: XCTestCase {
         }
 
         let JSON = ["a": "b", "c": "d"]
-        let test = try? Test(map: Mapper(JSON: JSON))
+        let test = try? Test(map: Mapper(JSON: JSON as NSDictionary))
         let parsedJSON = test?.JSON as? [String: String] ?? [:]
         XCTAssertTrue(parsedJSON == JSON)
     }

--- a/Tests/Mapper/TransformTests.swift
+++ b/Tests/Mapper/TransformTests.swift
@@ -45,7 +45,7 @@ final class TransformTests: XCTestCase {
             ]
         ]
 
-        let test = Test.from(JSON)
+        let test = Test.from(JSON as NSDictionary)
         XCTAssertTrue(test?.dictionary.count == 2)
         XCTAssertTrue(test?.dictionary["hi"] == Example(key: "hi", value: 1))
         XCTAssertTrue(test?.dictionary["bye"] == Example(key: "bye", value: 2))
@@ -95,7 +95,7 @@ final class TransformTests: XCTestCase {
             ]
         ]
 
-        let test = try? Test(map: Mapper(JSON: JSON))
+        let test = try? Test(map: Mapper(JSON: JSON as NSDictionary))
         XCTAssertNil(test)
     }
 


### PR DESCRIPTION
My team and I were interested in Lyft/mapper as a replacement for ObjectMapper and we needed it to work with swift3 beta 6.

This is just a proposal that makes the tests succeed, but may not be the best solution.
Some method parameters should be adjusted to fit the spirit of the ['Grand renaming'](https://littlebitesofcocoa.com/243-the-great-swift-3-rename) more closely.
For example this [method](https://github.com/lyft/mapper/blob/swift-3.0/Sources/Mapper.swift#L404) that could be renamed to:
`JSON(from field: String)` so it would read `let result = JSON(from: string)`
 
Furthermore we need to be aware that a 'var some: Any' can now be downcast to 'AnyObject' everytime, like [here](https://github.com/lyft/mapper/compare/swift-3.0...Bersaelor:swift-3.0#diff-df0ab80b86decf5ebc24ab5f19f53868R417). 