### PR TITLE
Fix TimeInterval test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 - Fix Xcode 8.1 `Any` -> `Any?` warning
   [Keith Smiley](https://github.com/keith)
   [#87](https://github.com/lyft/mapper/pull/87)
+- Fix `TimeInterval` test
+  [Keith Smiley](https://github.com/keith)
+  [#88](https://github.com/lyft/mapper/pull/88)
 
 # 5.0.0
 

--- a/Tests/MapperTests/NormalValueTests.swift
+++ b/Tests/MapperTests/NormalValueTests.swift
@@ -22,8 +22,8 @@ final class NormalValueTests: XCTestCase {
             }
         }
 
-        let test = try? Test(map: Mapper(JSON: ["time": 123]))
-        XCTAssertTrue(test?.string == 123)
+        let test = try? Test(map: Mapper(JSON: ["time": 123.0]))
+        XCTAssertTrue(test?.string == 123.0)
     }
 
     func testMappingMissingKey() {


### PR DESCRIPTION
As of Swift 3 this test no longer implicitly converts Ints to Doubles.
This is still kind of an issue since that means this feature broke with
Swift 3, but that will be addressed with a future PR.