### PR TITLE
Fix implicit number type conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 ## Bug Fixes
 
-- None
+- Fix implicit `Int` -> other number type conversions
+  [Keith Smiley](https://github.com/keith)
+  [#89](https://github.com/lyft/mapper/pull/89)
 
 # 5.0.0
 

--- a/Tests/MapperTests/NormalValueTests.swift
+++ b/Tests/MapperTests/NormalValueTests.swift
@@ -26,6 +26,42 @@ final class NormalValueTests: XCTestCase {
         XCTAssertTrue(test?.string == 123)
     }
 
+    func testImplicitlyMappingDoubleFromInt() {
+        struct Test: Mappable {
+            let double: Double
+            init(map: Mapper) throws {
+                try self.double = map.from("double")
+            }
+        }
+
+        let test = try? Test(map: Mapper(JSON: ["double": 321]))
+        XCTAssertTrue(test?.double == 321)
+    }
+
+    func testImplicitlyMappingFloatFromInt() {
+        struct Test: Mappable {
+            let float: Float
+            init(map: Mapper) throws {
+                try self.float = map.from("float")
+            }
+        }
+
+        let test = try? Test(map: Mapper(JSON: ["float": 789]))
+        XCTAssertTrue(test?.float == 789)
+    }
+
+    func testImplicitlyMappingUIntFromInt() {
+        struct Test: Mappable {
+            let uint: UInt
+            init(map: Mapper) throws {
+                try self.uint = map.from("uint")
+            }
+        }
+
+        let test = try? Test(map: Mapper(JSON: ["uint": 567]))
+        XCTAssertTrue(test?.uint == 567)
+    }
+
     func testMappingMissingKey() {
         struct Test: Mappable {
             let string: String


### PR DESCRIPTION
Note as of opening this, this doesn't actually fix anything, just adds some failing tests (in Xcode 8.1 at least) so that we can fix these shortly. We're not going to merge this until we have a fix.