### PR TITLE
Add JSONSerialization integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 ## Enhancements
 
-- None
+- Add JSONSerialization integration tests
+  [Keith Smiley](https://github.com/keith)
+  [#76](https://github.com/lyft/mapper/pull/90)
 
 ## Bug Fixes
 

--- a/Mapper.xcodeproj/project.pbxproj
+++ b/Mapper.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		C207F6EB1D7F286700EBCC74 /* RawRepresentibleValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C207F6E21D7F286700EBCC74 /* RawRepresentibleValueTests.swift */; };
 		C207F6EC1D7F286700EBCC74 /* TransformTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C207F6E31D7F286700EBCC74 /* TransformTests.swift */; };
 		C2B2A5761D3DE82700F7E7DE /* NSDictionary+Safety.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2B2A5751D3DE82700F7E7DE /* NSDictionary+Safety.swift */; };
+		C2BBD0C81DD430F400CB9F4E /* JSONSerializationIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2BBD0C61DD430AC00CB9F4E /* JSONSerializationIntegrationTests.swift */; };
 		C2C036FA1C2B1A0B003FB853 /* Convertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2C036F31C2B1A0B003FB853 /* Convertible.swift */; };
 		C2C036FB1C2B1A0B003FB853 /* MapperError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2C036F41C2B1A0B003FB853 /* MapperError.swift */; };
 		C2C036FC1C2B1A0B003FB853 /* Mappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2C036F51C2B1A0B003FB853 /* Mappable.swift */; };
@@ -52,6 +53,7 @@
 		C207F6E21D7F286700EBCC74 /* RawRepresentibleValueTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RawRepresentibleValueTests.swift; sourceTree = "<group>"; };
 		C207F6E31D7F286700EBCC74 /* TransformTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransformTests.swift; sourceTree = "<group>"; };
 		C2B2A5751D3DE82700F7E7DE /* NSDictionary+Safety.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSDictionary+Safety.swift"; sourceTree = "<group>"; };
+		C2BBD0C61DD430AC00CB9F4E /* JSONSerializationIntegrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONSerializationIntegrationTests.swift; sourceTree = "<group>"; };
 		C2C036D11C2B180D003FB853 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C2C036D41C2B180D003FB853 /* UniversalFramework_Base.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = UniversalFramework_Base.xcconfig; sourceTree = "<group>"; };
 		C2C036D51C2B180D003FB853 /* UniversalFramework_Framework.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = UniversalFramework_Framework.xcconfig; sourceTree = "<group>"; };
@@ -103,6 +105,7 @@
 				C207F6DC1D7F286700EBCC74 /* CustomTransformationTests.swift */,
 				C207F6DD1D7F286700EBCC74 /* ErrorTests.swift */,
 				C207F6DE1D7F286700EBCC74 /* InitializerTests.swift */,
+				C2BBD0C61DD430AC00CB9F4E /* JSONSerializationIntegrationTests.swift */,
 				C207F6DF1D7F286700EBCC74 /* MappableValueTests.swift */,
 				C207F6E01D7F286700EBCC74 /* NormalValueTests.swift */,
 				C207F6E11D7F286700EBCC74 /* OptionalValueTests.swift */,
@@ -256,6 +259,7 @@
 				C207F6E51D7F286700EBCC74 /* CustomTransformationTests.swift in Sources */,
 				C207F6E81D7F286700EBCC74 /* MappableValueTests.swift in Sources */,
 				C207F6EA1D7F286700EBCC74 /* OptionalValueTests.swift in Sources */,
+				C2BBD0C81DD430F400CB9F4E /* JSONSerializationIntegrationTests.swift in Sources */,
 				C207F6E91D7F286700EBCC74 /* NormalValueTests.swift in Sources */,
 				C207F6E61D7F286700EBCC74 /* ErrorTests.swift in Sources */,
 			);

--- a/Tests/MapperTests/JSONSerializationIntegrationTests.swift
+++ b/Tests/MapperTests/JSONSerializationIntegrationTests.swift
@@ -1,0 +1,32 @@
+import Mapper
+import XCTest
+
+final class JSONSerializationIntegrationTests: XCTestCase {
+    func testDecodingNormalJSON() {
+        struct Test: Mappable {
+            let string: String
+            init(map: Mapper) throws {
+                try self.string = map.from("string")
+            }
+        }
+
+        let data = "{\"string\": \"hi\"}".data(using: .utf8)
+        let dictionary = data.flatMap { (try? JSONSerialization.jsonObject(with: $0)) as? NSDictionary }
+        let test = dictionary.flatMap { try? Test.init(map: Mapper(JSON: $0)) }
+        XCTAssert(test?.string == "hi")
+    }
+
+    func testDecodingDoubleFromJSON() {
+        struct Test: Mappable {
+            let time: TimeInterval
+            init(map: Mapper) throws {
+                try self.time = map.from("time")
+            }
+        }
+
+        let data = "{\"time\": 123}".data(using: .utf8)
+        let dictionary = data.flatMap { (try? JSONSerialization.jsonObject(with: $0)) as? NSDictionary }
+        let test = dictionary.flatMap { try? Test.init(map: Mapper(JSON: $0)) }
+        XCTAssert(test?.time == 123.0)
+    }
+}


### PR DESCRIPTION
Turns out that dictionaries created via `NSJSONSerialization` act
slightly differently than ones created literally through Swift. As far
as we can tell this is caused by the bridging that happens between
Objective-C and Swift. This adds some sanity checks for Double values
specifically since NSNumbers act differently when passed through this
filter.