### PR TITLE
Run tests with release mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Add JSONSerialization integration tests
   [Keith Smiley](https://github.com/keith)
   [#76](https://github.com/lyft/mapper/pull/90)
+- Test with optimizations
+  [Keith Smiley](https://github.com/keith)
+  [#92](https://github.com/lyft/mapper/pull/92)
 
 ## Bug Fixes
 
@@ -26,7 +29,6 @@
 - Swift 3.0 support
   [Keith Smiley](https://github.com/keith)
   [#76](https://github.com/lyft/mapper/pull/76)
-
 - Update transformation function to take `Any`
   [Keith Smiley](https://github.com/keith)
   [#76](https://github.com/lyft/mapper/pull/76)

--- a/Mapper.xcodeproj/xcshareddata/xcschemes/Mapper.xcscheme
+++ b/Mapper.xcodeproj/xcshareddata/xcschemes/Mapper.xcscheme
@@ -23,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"


### PR DESCRIPTION
Since Mapper is a small enough project it doesn't meaningfully impact
compile times to test with optimizations on. The benefit here is that we
won't be surprised when a Swift whole module optimization bug changes
the behavior in a bad way.