### PR TITLE
Creating Contextual Mappable Protocol

### DIFF
--- a/Mapper.xcodeproj/project.pbxproj
+++ b/Mapper.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		364F2E5B1E0233B7000D1829 /* ContextualMappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 364F2E5A1E0233B7000D1829 /* ContextualMappable.swift */; };
+		364F2E5E1E0236B5000D1829 /* ContextualMappableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 364F2E5C1E023504000D1829 /* ContextualMappableTests.swift */; };
 		C201748E1BD5509D00E4FE18 /* Mapper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C20174831BD5509D00E4FE18 /* Mapper.framework */; };
 		C20586EC1CDEAD9900658A67 /* DefaultConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20586EB1CDEAD9900658A67 /* DefaultConvertible.swift */; };
 		C207F6E41D7F286700EBCC74 /* ConvertibleValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C207F6DB1D7F286700EBCC74 /* ConvertibleValueTests.swift */; };
@@ -40,6 +42,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		364F2E5A1E0233B7000D1829 /* ContextualMappable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContextualMappable.swift; sourceTree = "<group>"; };
+		364F2E5C1E023504000D1829 /* ContextualMappableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContextualMappableTests.swift; sourceTree = "<group>"; };
 		C20174831BD5509D00E4FE18 /* Mapper.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Mapper.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C201748D1BD5509D00E4FE18 /* MapperTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MapperTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C20586EB1CDEAD9900658A67 /* DefaultConvertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultConvertible.swift; sourceTree = "<group>"; };
@@ -111,6 +115,7 @@
 				C207F6E11D7F286700EBCC74 /* OptionalValueTests.swift */,
 				C207F6E21D7F286700EBCC74 /* RawRepresentibleValueTests.swift */,
 				C207F6E31D7F286700EBCC74 /* TransformTests.swift */,
+				364F2E5C1E023504000D1829 /* ContextualMappableTests.swift */,
 			);
 			path = MapperTests;
 			sourceTree = "<group>";
@@ -146,6 +151,7 @@
 				C2C036F71C2B1A0B003FB853 /* NSURL+Convertible.swift */,
 				C2C036F91C2B1A0B003FB853 /* Transform.swift */,
 				C2C036F81C2B1A0B003FB853 /* Transform+Dictionary.swift */,
+				364F2E5A1E0233B7000D1829 /* ContextualMappable.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -238,6 +244,7 @@
 			files = (
 				C2C036FF1C2B1A0B003FB853 /* Transform+Dictionary.swift in Sources */,
 				C2C036FE1C2B1A0B003FB853 /* NSURL+Convertible.swift in Sources */,
+				364F2E5B1E0233B7000D1829 /* ContextualMappable.swift in Sources */,
 				C2B2A5761D3DE82700F7E7DE /* NSDictionary+Safety.swift in Sources */,
 				C2C036FD1C2B1A0B003FB853 /* Mapper.swift in Sources */,
 				C2C037001C2B1A0B003FB853 /* Transform.swift in Sources */,
@@ -258,6 +265,7 @@
 				C207F6EC1D7F286700EBCC74 /* TransformTests.swift in Sources */,
 				C207F6E51D7F286700EBCC74 /* CustomTransformationTests.swift in Sources */,
 				C207F6E81D7F286700EBCC74 /* MappableValueTests.swift in Sources */,
+				364F2E5E1E0236B5000D1829 /* ContextualMappableTests.swift in Sources */,
 				C207F6EA1D7F286700EBCC74 /* OptionalValueTests.swift in Sources */,
 				C2BBD0C81DD430F400CB9F4E /* JSONSerializationIntegrationTests.swift in Sources */,
 				C207F6E91D7F286700EBCC74 /* NormalValueTests.swift in Sources */,

--- a/Sources/ContextualMappable.swift
+++ b/Sources/ContextualMappable.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public protocol ContextualMappable {
+    associatedtype Context
+    /// Define how your custom object is created from a Mapper object with a context.
+    init(map: Mapper, context: Context) throws
+}

--- a/Sources/Mapper.swift
+++ b/Sources/Mapper.swift
@@ -117,6 +117,15 @@ public struct Mapper {
         throw MapperError.typeMismatchError(field: field, value: value, type: NSDictionary.self)
     }
 
+    public func from<T: ContextualMappable>(_ field: String, context: T.Context) throws -> T {
+        let value = try self.JSONFromField(field)
+        if let JSON = value as? NSDictionary {
+            return try T(map: Mapper(JSON: JSON), context: context)
+        }
+
+        throw MapperError.typeMismatchError(field: field, value: value, type: NSDictionary.self)
+    }
+
     /// Get an array of Mappable values from the given field in the source data
     ///
     /// This allows you to transparently have nested arrays of Mappable values
@@ -150,6 +159,10 @@ public struct Mapper {
     /// - returns: The value for the given field, if it can be converted to the expected type T otherwise nil
     public func optionalFrom<T: Mappable>(_ field: String) -> T? {
         return try? self.from(field)
+    }
+
+    public func optionalFrom<T: ContextualMappable>(_ field: String, context: T.Context) -> T? {
+        return try? self.from(field, context: context)
     }
 
     /// Get an optional array of Mappable values from the given field in the source data

--- a/Tests/MapperTests/ContextualMappableTests.swift
+++ b/Tests/MapperTests/ContextualMappableTests.swift
@@ -1,0 +1,31 @@
+import Mapper
+import XCTest
+
+private enum Currency {
+    case USD
+    case GBP
+    case EUR
+}
+
+private struct Price: ContextualMappable {
+    typealias Context = Currency
+    let valueInCurrency: Double
+    init(map: Mapper, context: Currency) throws {
+        let cents: Double = try map.from("value")
+        switch context {
+        case .USD:
+            self.valueInCurrency = cents
+        case .GBP:
+            self.valueInCurrency = cents * 1.5
+        case .EUR:
+            self.valueInCurrency = cents * 1.2
+        }
+    }
+}
+
+final class ContextualMappableTests: XCTestCase {
+    func testContextualMappable() {
+        let test = try? Price(map: Mapper(JSON: ["value": 1000.0]), context: .EUR)
+        XCTAssertTrue(test?.valueInCurrency == 1200.0)
+    }
+}


### PR DESCRIPTION
I would like to introduce a ContextualMappable protocol in addition to the Mappable protocol. The ContextualMappable protocol allows you to pass a context to the initializer in addition to the map. This is useful in cases where the information is mapped differently based on some context, and is cleaner than using a Transform because it is strictly typed and only one function call. I didn't fully document or test it yet because I wanted to hear your thoughts on the matter before investing the time to make it shippable.