### PR TITLE
Don't expose NSDictionary extension to Objective-C

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 ## Enhancements
 
-- None
+- Add `@nonobjc` to our `NSDictionary` extension
+  [Keith Smiley](https://github.com/keith)
+  [#107](https://github.com/lyft/mapper/pull/107)
 
 ## Bug Fixes
 
@@ -24,7 +26,7 @@
 
 - Add JSONSerialization integration tests
   [Keith Smiley](https://github.com/keith)
-  [#76](https://github.com/lyft/mapper/pull/90)
+  [#90](https://github.com/lyft/mapper/pull/90)
 - Test with optimizations
   [Keith Smiley](https://github.com/keith)
   [#92](https://github.com/lyft/mapper/pull/92)

--- a/Sources/NSDictionary+Safety.swift
+++ b/Sources/NSDictionary+Safety.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 extension NSDictionary {
+    @nonobjc
     func safeValue(forKeyPath keyPath: String) -> Any? {
         var object: Any? = self
         var keys = keyPath.characters.split(separator: ".").map(String.init)


### PR DESCRIPTION
This is the default behavior when extending an Objective-C class, but
this isn't needed for our use.