### PR TITLE
Remove duplicate Hashable conformation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,9 @@
 
 ## Enhancements
 
-- None
+- Remove duplicate `Hashable` protocol conformance
+  [Keith Smiley](https://github.com/keith)
+  [#108](https://github.com/lyft/mapper/pull/108)
 
 ## Bug Fixes
 

--- a/Mapper.xcodeproj/project.pbxproj
+++ b/Mapper.xcodeproj/project.pbxproj
@@ -200,7 +200,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 0820;
+				LastUpgradeCheck = 0830;
 				ORGANIZATIONNAME = Lyft;
 				TargetAttributes = {
 					C20174821BD5509D00E4FE18 = {

--- a/Mapper.xcodeproj/xcshareddata/xcschemes/Mapper.xcscheme
+++ b/Mapper.xcodeproj/xcshareddata/xcschemes/Mapper.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sources/Transform+Dictionary.swift
+++ b/Sources/Transform+Dictionary.swift
@@ -44,7 +44,7 @@ public extension Transform {
     /// - returns: A dictionary of [U: T] where the keys U are produced from the passed `key` function and the
     ///            values T are the objects
     public static func toDictionary<T, U>(key getKey: @escaping (T) -> U) ->
-        (_ object: Any) throws -> [U: T] where T: Mappable, U: Hashable
+        (_ object: Any) throws -> [U: T] where T: Mappable
     {
         return { object in
             guard let objects = object as? [NSDictionary] else {


### PR DESCRIPTION
Swift 4 now has a warning for this, but this is backwards compatible to
Swift 3 as well.