### PR TITLE
Remove characters call from string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 ## Enhancements
 
-- None
+- Remove call to characters on string
+  [Keith Smiley](https://github.com/keith)
+  [#116](https://github.com/lyft/mapper/pull/116)
 
 # 7.0.0
 

--- a/Sources/NSDictionary+Safety.swift
+++ b/Sources/NSDictionary+Safety.swift
@@ -4,7 +4,7 @@ extension NSDictionary {
     @nonobjc
     func safeValue(forKeyPath keyPath: String) -> Any? {
         var object: Any? = self
-        var keys = keyPath.characters.split(separator: ".").map(String.init)
+        var keys = keyPath.split(separator: ".").map(String.init)
 
         while !keys.isEmpty, let currentObject = object {
             let key = keys.remove(at: 0)


### PR DESCRIPTION
This isn't deprecated yet, but it is on swiftc master