### PR TITLE
Support U?Int(32|64) Conversion Natively

### DIFF
--- a/Sources/DefaultConvertible.swift
+++ b/Sources/DefaultConvertible.swift
@@ -30,7 +30,11 @@ extension NSArray: DefaultConvertible {}
 
 extension String: DefaultConvertible {}
 extension Int: DefaultConvertible {}
+extension Int32: DefaultConvertible {}
+extension Int64: DefaultConvertible {}
 extension UInt: DefaultConvertible {}
+extension UInt32: DefaultConvertible {}
+extension UInt64: DefaultConvertible {}
 extension Float: DefaultConvertible {}
 extension Double: DefaultConvertible {}
 extension Bool: DefaultConvertible {}


### PR DESCRIPTION
These are built-in types that applications use often to eliminate variants in
32bit/64bit platforms. A Unix timestamp in milliseconds can't be parsed from
json to an `Int` on 32bit devices, for example.