### PR TITLE
Return valid array with only valid objects

### DIFF
--- a/Sources/Mappable.swift
+++ b/Sources/Mappable.swift
@@ -40,7 +40,7 @@ public extension Mappable {
     /// - returns: An array of the created objects, or nil if creating threw
     public static func from(_ JSON: NSArray) -> [Self]? {
         if let array = JSON as? [NSDictionary] {
-            return try? array.map { try self.init(map: Mapper(JSON: $0)) }
+            return array.flatMap { try? self.init(map: Mapper(JSON: $0)) }
         }
 
         return nil


### PR DESCRIPTION
When only one or two objects from an JSON array throws, the array should still be valid with all the other valid objects.