### PR TITLE
Support Array Of Fields For Custom Transformation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 ## Enhancements
 
-- None
+- Support Array Of Fields For Custom Transformation
+  [Daniel Duan](https://github.com/dduan)
+  [#120](https://github.com/lyft/mapper/pull/120)
 
 # 7.1.0
 

--- a/Sources/Mapper.swift
+++ b/Sources/Mapper.swift
@@ -346,6 +346,24 @@ public struct Mapper {
         return (try? transformation(try self.JSONFromField(field))).flatMap { $0 }
     }
 
+    /// Get an optional typed value from the given fields by using the given transformation
+    ///
+    /// - parameter fields:         The array of fields to retrieve from the source data, can be an empty
+    ///                             string to return the entire data set
+    /// - parameter transformation: The transformation function used to create the expected value
+    ///
+    /// - returns: The value of type T for the given field, if the transformation function doesn't throw
+    ///            otherwise nil
+    public func optionalFrom<T>(_ fields: [String], transformation: (Any) throws -> T?) -> T? {
+        for field in fields {
+            if let value = try? transformation(try self.JSONFromField(field)) {
+                return value
+            }
+        }
+
+        return nil
+    }
+
     // MARK: - Private
 
     /// Get the object for a given field. If an empty string is passed, return the entire data source. This

--- a/Tests/MapperTests/CustomTransformationTests.swift
+++ b/Tests/MapperTests/CustomTransformationTests.swift
@@ -75,4 +75,64 @@ final class CustomTransformationTests: XCTestCase {
             XCTFail("Shouldn't have failed to create Test")
         }
     }
+
+    func testOptionalCustomTransformationArrayOfKeys() {
+        struct Test: Mappable {
+            let value: Int?
+            init(map: Mapper) throws {
+                value = map.optionalFrom(["a", "b"], transformation: { thing in
+                    if let a = thing as? Int {
+                        return a + 1
+                    }
+                    throw MapperError.customError(field: nil, message: "")
+                })
+            }
+        }
+
+        do {
+            let test = try Test(map: Mapper(JSON: ["a": "##", "b": 1]))
+            XCTAssertEqual(test.value, 2)
+        } catch {
+            XCTFail("Shouldn't have failed to create Test")
+        }
+    }
+
+    func testOptionalCustomTransformationArrayOfKeysFails() {
+        struct Test: Mappable {
+            let value: Int?
+            init(map: Mapper) throws {
+                value = map.optionalFrom(["a", "b"], transformation: { _ in
+                    throw MapperError.customError(field: nil, message: "")
+                })
+            }
+        }
+
+        do {
+            let test = try Test(map: Mapper(JSON: ["a": "##", "b": 1]))
+            XCTAssertNil(test.value)
+        } catch {
+            XCTFail("Shouldn't have failed to create Test")
+        }
+    }
+
+    func testOptionalCustomTransformationArrayOfKeysReturnsNil() {
+        struct Test: Mappable {
+            let value: Int?
+            init(map: Mapper) throws {
+                value = map.optionalFrom(["a", "b"], transformation: { thing in
+                    if let a = thing as? Int {
+                        return a + 1
+                    }
+                    throw MapperError.customError(field: nil, message: "")
+                })
+            }
+        }
+
+        do {
+            let test = try Test(map: Mapper(JSON: [:]))
+            XCTAssertNil(test.value)
+        } catch {
+            XCTFail("Shouldn't have failed to create Test")
+        }
+    }
 }


### PR DESCRIPTION
Returns `nil` if key doesn't exist or transformation for found value throws.