### PR TITLE
Added rescue handling for unsanitized URL strings

### DIFF
--- a/Sources/URL+Convertible.swift
+++ b/Sources/URL+Convertible.swift
@@ -19,6 +19,12 @@ extension URL: Convertible {
             return url
         }
 
+        // Rescue
+        if let sanitized = string.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+            let url = URL(string: sanitized) {
+            return url
+        }
+
         throw MapperError.customError(field: nil, message: "'\(string)' is not a valid URL")
     }
 }

--- a/Tests/MapperTests/ConvertibleValueTests.swift
+++ b/Tests/MapperTests/ConvertibleValueTests.swift
@@ -56,6 +56,18 @@ final class ConvertibleValueTests: XCTestCase {
         XCTAssertTrue(test?.URLs.count == 2)
     }
 
+    func testSanitizingURL() {
+        struct Test: Mappable {
+            let URL: URL
+            init(map: Mapper) throws {
+                try self.URL = map.from("url")
+            }
+        }
+
+        let test = try? Test(map: Mapper(JSON: ["url": "https://google.com?param=in|20:20"]))
+        XCTAssertTrue(test?.URL.host = "google.com")
+    }
+
     func testOptionalArrayOfConvertibles() {
         struct Test: Mappable {
             let URLs: [URL]?

--- a/Tests/MapperTests/ConvertibleValueTests.swift
+++ b/Tests/MapperTests/ConvertibleValueTests.swift
@@ -65,7 +65,7 @@ final class ConvertibleValueTests: XCTestCase {
         }
 
         let test = try? Test(map: Mapper(JSON: ["url": "https://google.com?param=in|20:20"]))
-        XCTAssertTrue(test?.URL.host = "google.com")
+        XCTAssertTrue(test?.URL.host == "google.com")
     }
 
     func testOptionalArrayOfConvertibles() {


### PR DESCRIPTION
Sanitizing URL strings will result in a higher success rate of transforming strings to URLs.