### PR TITLE
Support non-optional mapping from list of fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Add `optionalFrom` for arrays of `RawRepresentable`s
   [Keith Smiley](https://github.com/keith)
   [#125](https://github.com/lyft/mapper/pull/125)
+- Support non-optional mapping from list of fields
+  [Michael Rebello](https://github.com/rebello95)
+  [#126](https://github.com/lyft/mapper/pull/126)
 
 # 7.2.0
 

--- a/Sources/Mapper.swift
+++ b/Sources/Mapper.swift
@@ -68,6 +68,24 @@ public struct Mapper {
         return nil
     }
 
+    /// Get a RawRepresentable value from the specified list of fields. This returns the first value produced
+    /// in order based on the array of fields.
+    ///
+    /// - parameter fields: The array of fields to check from the source data.
+    ///
+    /// - throws: MapperError.missingFieldError if none of the fields have an acceptable value.
+    ///
+    /// - returns: The first non-nil value to be produced from the array of fields.
+    public func from<T: RawRepresentable>(_ fields: [String]) throws -> T {
+        for field in fields {
+            if let value: T = try? self.from(field) {
+                return value
+            }
+        }
+
+        throw MapperError.missingFieldError(field: fields.joined(separator: ", "))
+    }
+
     /// Get an array of RawRepresentable values from a field in the the source data.
     ///
     /// - note: If T.init(rawValue:) fails given the T.RawValue from the array of source data, that value will
@@ -198,6 +216,24 @@ public struct Mapper {
         }
 
         return nil
+    }
+
+    /// Get a value from the specified list of fields. This returns the first value produced in order based on
+    /// the array of fields.
+    ///
+    /// - parameter fields: The array of fields to check from the source data.
+    ///
+    /// - throws: MapperError.missingFieldError if none of the fields have an acceptable value.
+    ///
+    /// - returns: The first non-nil value to be produced from the array of fields.
+    public func from<T: Mappable>(_ fields: [String]) throws -> T {
+        for field in fields {
+            if let value: T = try? self.from(field) {
+                return value
+            }
+        }
+
+        throw MapperError.missingFieldError(field: fields.joined(separator: ", "))
     }
 
     // MARK: - T: Convertible
@@ -333,6 +369,24 @@ public struct Mapper {
         }
 
         return nil
+    }
+
+    /// Get a Convertible value from the specified list of fields. This returns the first value produced in
+    /// order based on the array of fields.
+    ///
+    /// - parameter fields: The array of fields to check from the source data.
+    ///
+    /// - throws: MapperError.missingFieldError if none of the fields have an acceptable value.
+    ///
+    /// - returns: The first non-nil value to be produced from the array of fields.
+    public func from<T: Convertible>(_ fields: [String]) throws -> T where T == T.ConvertedType {
+        for field in fields {
+            if let value: T = try? self.from(field, transformation: T.fromMap) {
+                return value
+            }
+        }
+
+        throw MapperError.missingFieldError(field: fields.joined(separator: ", "))
     }
 
     // MARK: - Custom Transformation

--- a/Tests/MapperTests/ConvertibleValueTests.swift
+++ b/Tests/MapperTests/ConvertibleValueTests.swift
@@ -128,6 +128,30 @@ final class ConvertibleValueTests: XCTestCase {
         XCTAssertNil(test.URL)
     }
 
+    func testConvertibleArrayOfKeysDoesNotThrow() {
+        struct Test: Mappable {
+            let string: String
+            init(map: Mapper) throws {
+                try self.string = map.from(["a", "b"])
+            }
+        }
+
+        let test = try? Test(map: Mapper(JSON: ["b": "someValue"]))
+        XCTAssertTrue(test?.string == "someValue")
+    }
+
+    func testConvertibleArrayOfKeysThrowsWhenMissing() {
+        struct Test: Mappable {
+            let string: String
+            init(map: Mapper) throws {
+                try self.string = map.from(["a", "b"])
+            }
+        }
+
+        let test = try? Test(map: Mapper(JSON: [:]))
+        XCTAssertNil(test)
+    }
+
     func testDictionaryConvertible() {
         struct Test: Mappable {
             let dictionary: [String: Int]

--- a/Tests/MapperTests/MappableValueTests.swift
+++ b/Tests/MapperTests/MappableValueTests.swift
@@ -169,4 +169,42 @@ final class MappableValueTests: XCTestCase {
             XCTFail("Failed to create Test")
         }
     }
+
+    func testMappableArrayOfKeysDoesNotThrow() {
+        struct Test: Mappable {
+            let nest: Nested
+            init(map: Mapper) throws {
+                try self.nest = map.from(["a", "b"])
+            }
+        }
+
+        struct Nested: Mappable {
+            let string: String
+            init(map: Mapper) throws {
+                try self.string = map.from("string")
+            }
+        }
+
+        let test = try? Test(map: Mapper(JSON: ["b": ["string": "hi"]]))
+        XCTAssertTrue(test?.nest.string == "hi")
+    }
+
+    func testMappableArrayOfKeysThrowsWhenMissing() {
+        struct Test: Mappable {
+            let nest: Nested
+            init(map: Mapper) throws {
+                try self.nest = map.from(["a", "b"])
+            }
+        }
+
+        struct Nested: Mappable {
+            let string: String
+            init(map: Mapper) throws {
+                try self.string = map.from("string")
+            }
+        }
+
+        let test = try? Test(map: Mapper(JSON: [:]))
+        XCTAssertNil(test)
+    }
 }

--- a/Tests/MapperTests/RawRepresentibleValueTests.swift
+++ b/Tests/MapperTests/RawRepresentibleValueTests.swift
@@ -130,6 +130,38 @@ final class RawRepresentibleValueTests: XCTestCase {
         XCTAssertNil(test.value)
     }
 
+    func testRawRepresentibleArrayOfKeysDoesNotThrow() {
+        struct Test: Mappable {
+            let value: Value
+            init(map: Mapper) throws {
+                try self.value = map.from(["a", "b"])
+            }
+        }
+
+        enum Value: String {
+            case first = "hi"
+        }
+
+        let test = try? Test(map: Mapper(JSON: ["a": 1, "b": "hi"]))
+        XCTAssertTrue(test?.value == .first)
+    }
+
+    func testRawRepresentibleArrayOfKeysThrowsWhenMissing() {
+        struct Test: Mappable {
+            let value: Value
+            init(map: Mapper) throws {
+                try self.value = map.from(["a", "b"])
+            }
+        }
+
+        enum Value: String {
+            case first = "hi"
+        }
+
+        let test = try? Test(map: Mapper(JSON: ["a": 1, "b": 2]))
+        XCTAssertNil(test)
+    }
+
     func testArrayOfValuesWithMissingKey() {
         struct Test: Mappable {
             let value: [Value]

--- a/Tests/MapperTests/RawRepresentibleValueTests.swift
+++ b/Tests/MapperTests/RawRepresentibleValueTests.swift
@@ -107,10 +107,10 @@ final class RawRepresentibleValueTests: XCTestCase {
         }
 
         enum Value: String {
-            case first = "hi"
+            case first
         }
 
-        let test = Test(map: Mapper(JSON: ["a": "nope", "b": "hi"]))
+        let test = Test(map: Mapper(JSON: ["a": "nope", "b": "first"]))
         XCTAssertTrue(test.value == .first)
     }
 
@@ -123,7 +123,7 @@ final class RawRepresentibleValueTests: XCTestCase {
         }
 
         enum Value: String {
-            case first = "hi"
+            case first
         }
 
         let test = Test(map: Mapper(JSON: [:]))
@@ -139,10 +139,10 @@ final class RawRepresentibleValueTests: XCTestCase {
         }
 
         enum Value: String {
-            case first = "hi"
+            case first
         }
 
-        let test = try? Test(map: Mapper(JSON: ["a": 1, "b": "hi"]))
+        let test = try? Test(map: Mapper(JSON: ["a": 1, "b": "first"]))
         XCTAssertTrue(test?.value == .first)
     }
 
@@ -155,7 +155,7 @@ final class RawRepresentibleValueTests: XCTestCase {
         }
 
         enum Value: String {
-            case first = "hi"
+            case first
         }
 
         let test = try? Test(map: Mapper(JSON: ["a": 1, "b": 2]))
@@ -171,7 +171,7 @@ final class RawRepresentibleValueTests: XCTestCase {
         }
 
         enum Value: String {
-            case first = "hi"
+            case first
         }
 
         do {
@@ -193,7 +193,7 @@ final class RawRepresentibleValueTests: XCTestCase {
         }
 
         enum Value: String {
-            case first = "hi"
+            case first
         }
 
         do {
@@ -217,7 +217,7 @@ final class RawRepresentibleValueTests: XCTestCase {
         }
 
         enum Value: String {
-            case first = "hi"
+            case first
         }
 
         do {
@@ -240,11 +240,11 @@ final class RawRepresentibleValueTests: XCTestCase {
         }
 
         enum Value: String {
-            case first = "hi"
+            case first
         }
 
         do {
-            let test = try Test(map: Mapper(JSON: ["a": ["hi", "invalid"]]))
+            let test = try Test(map: Mapper(JSON: ["a": ["first", "invalid"]]))
             XCTAssertEqual(test.values.count, 1)
             XCTAssert(test.values.contains(.first))
         } catch let error {
@@ -254,7 +254,7 @@ final class RawRepresentibleValueTests: XCTestCase {
 
     func testArrayOfValuesInsertsDefault() {
         enum Value: String {
-            case first = "hi"
+            case first
         }
 
         struct Test: Mappable {


### PR DESCRIPTION
This adds support for doing non-optional mapping from a list of fields, similarly to how `map.optionalFrom(["a", "b"])` works.

This allows for usages such this, which was not previously possible:
```
let a = try map.from(["a", "b"])
```