### PR TITLE
Trim whitespace and newline characters from URL strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 ## Enhancements
 
-- None
+- Trim whitespace and newline characters from URL strings
+  [Tim Duhaylungsod](https://github.com/timominous)
+  [#127](https://github.com/lyft/mapper/pull/127)
 
 # 7.3.0
 

--- a/Sources/URL+Convertible.swift
+++ b/Sources/URL+Convertible.swift
@@ -15,7 +15,7 @@ extension URL: Convertible {
             throw MapperError.convertibleError(value: value, type: String.self)
         }
 
-        if let url = URL(string: string) {
+        if let url = URL(string: string.trimmingCharacters(in: .whitespacesAndNewlines)) {
             return url
         }
 

--- a/Tests/MapperTests/ConvertibleValueTests.swift
+++ b/Tests/MapperTests/ConvertibleValueTests.swift
@@ -43,6 +43,18 @@ final class ConvertibleValueTests: XCTestCase {
         let test = Test(map: Mapper(JSON: ["url": "##"]))
         XCTAssertNil(test.URL)
     }
+    
+    func testWhiteSpaceURL() {
+        struct Test: Mappable {
+            let URL: URL?
+            init(map: Mapper) {
+                self.URL = map.optionalFrom("url")
+            }
+        }
+        
+        let test = Test(map: Mapper(JSON: ["url": " https://google.com \n"]))
+        XCTAssertTrue(test.URL?.host == "google.com")
+    }
 
     func testArrayOfConvertibles() {
         struct Test: Mappable {

--- a/Tests/MapperTests/ConvertibleValueTests.swift
+++ b/Tests/MapperTests/ConvertibleValueTests.swift
@@ -43,7 +43,7 @@ final class ConvertibleValueTests: XCTestCase {
         let test = Test(map: Mapper(JSON: ["url": "##"]))
         XCTAssertNil(test.URL)
     }
-    
+
     func testWhiteSpaceURL() {
         struct Test: Mappable {
             let URL: URL?
@@ -51,7 +51,7 @@ final class ConvertibleValueTests: XCTestCase {
                 self.URL = map.optionalFrom("url")
             }
         }
-        
+
         let test = Test(map: Mapper(JSON: ["url": " https://google.com \n"]))
         XCTAssertTrue(test.URL?.host == "google.com")
     }


### PR DESCRIPTION
I don't know if there is contention against modifying the user input vs making the the mapping easier for the user. I feel like this is better than having to let the user create a custom transformation function and pass it on to all URL mappings.

Thoughts?