### PR TITLE
Adding optionalFrom for multiple fields to array of Mappable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 ## Enhancements
 
-- None
+- Support `optionalFrom` for array of fields to an array of `Mappable`s 
+  [Kris Gellci](https://github.com/kgellci)
+  [#132](https://github.com/lyft/mapper/pull/132)
 
 # 7.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - Support `optionalFrom` for array of fields to an array of `Mappable`s 
   [Kris Gellci](https://github.com/kgellci)
-  [#132](https://github.com/lyft/mapper/pull/132)
+  [#133](https://github.com/lyft/mapper/pull/133)
 
 # 7.4.0
 

--- a/Sources/Mapper.swift
+++ b/Sources/Mapper.swift
@@ -218,6 +218,22 @@ public struct Mapper {
         return nil
     }
 
+    /// Get an optional array of Mappable values from the given fields. This returns the first non-nil value
+    /// produced in order based on the array of fields
+    ///
+    /// - parameter fields: The array of fields to check from the source data.
+    ///
+    /// - returns: The first non-nil value to be produced from the array of fields, or nil if none exist
+    public func optionalFrom<T: Mappable>(_ fields: [String]) -> [T]? {
+        for field in fields {
+            if let value: [T] = try? self.from(field) {
+                return value
+            }
+        }
+
+        return nil
+    }
+
     /// Get a value from the specified list of fields. This returns the first value produced in order based on
     /// the array of fields.
     ///

--- a/Tests/MapperTests/OptionalValueTests.swift
+++ b/Tests/MapperTests/OptionalValueTests.swift
@@ -77,4 +77,31 @@ final class OptionalValueTests: XCTestCase {
         let test = Test(map: Mapper(JSON: [:]))
         XCTAssertNil(test.string)
     }
+
+    func testMappingOptionalArrayFromFields() {
+        struct Test: Mappable {
+            let string: String?
+            init(map: Mapper) {
+                self.string = map.optionalFrom(["s"])
+            }
+        }
+
+        let map = Mapper(JSON: ["key2": [["s": "a"], ["s": "b"], ["s": "c"]]])
+        let test: [Test]? = map.optionalFrom(["key1", "key2"])
+        XCTAssertTrue(test!.count == 3)
+        XCTAssertTrue(test![1].string == "b")
+    }
+
+    func testMappingOptionalArrayFromFieldsReturnsNil() {
+        struct Test: Mappable {
+            let string: String?
+            init(map: Mapper) {
+                self.string = map.optionalFrom(["s"])
+            }
+        }
+
+        let map = Mapper(JSON: ["key3": [["s": "a"], ["s": "b"], ["s": "c"]]])
+        let test: [Test]? = map.optionalFrom(["key1", "key2"])
+        XCTAssertNil(test)
+    }
 }

--- a/Tests/MapperTests/OptionalValueTests.swift
+++ b/Tests/MapperTests/OptionalValueTests.swift
@@ -88,8 +88,8 @@ final class OptionalValueTests: XCTestCase {
 
         let map = Mapper(JSON: ["key2": [["s": "a"], ["s": "b"], ["s": "c"]]])
         let test: [Test]? = map.optionalFrom(["key1", "key2"])
-        XCTAssertTrue(test!.count == 3)
-        XCTAssertTrue(test![1].string == "b")
+        XCTAssertTrue(test?.count == 3)
+        XCTAssertTrue(test?[1].string == "b")
     }
 
     func testMappingOptionalArrayFromFieldsReturnsNil() {


### PR DESCRIPTION
Adding support to call `optionalFrom` with an array of fields and get back an optional array of Mappable.

Example:

`let items: [Item]? = map.optionalFrom(["itemsKey", "items_key"])`