### PR TITLE
Remove Float DefaultConvertible conformance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Breaking
 
-- None
+- Remove `Float`'s `DefaultConvertible` conformance
+  [Keith Smiley](https://github.com/keith)
+  [#141](https://github.com/lyft/mapper/pull/141)
 
 ## Enhancements
 

--- a/Sources/DefaultConvertible.swift
+++ b/Sources/DefaultConvertible.swift
@@ -35,6 +35,5 @@ extension Int64: DefaultConvertible {}
 extension UInt: DefaultConvertible {}
 extension UInt32: DefaultConvertible {}
 extension UInt64: DefaultConvertible {}
-extension Float: DefaultConvertible {}
 extension Double: DefaultConvertible {}
 extension Bool: DefaultConvertible {}


### PR DESCRIPTION
Previously we assumed that Floats would be safe to cast to. But after
this discovery
https://twitter.com/drewmccormack/status/1020319238291165185 it turns
out that floats can only be converted from NSNumbers if you can "safely
express the value". This means in some cases like this one:

```swift
struct Foo {
    let bar: Float
    init(map: Mapper) throws {
        try self.bar = map.from("float")
    }
}

let foo = try? Foo(map: Mapper(JSON: ["float": 1.1]))
XCTAssertEqual(foo?.bar, 1.1)
```

Will be false, since `foo?.bar` will be `nil` here since our dictionary
is bridged to an NSDictionary, boxing the float in a NSNumber, and back
when we do a `NSNumber as? Float`. If you change the number in the above
example to `1.5`, it works as expected.

If users understand this risk and want to use floats, they can add this
`DefaultConvertible` conformance themselves.