### PR TITLE
Fix coverage script

### DIFF
--- a/Resources/coverage.sh
+++ b/Resources/coverage.sh
@@ -13,7 +13,7 @@ result="$(xcrun xccov view \
   "$profdata" \
   | python Resources/get-coverage.py Mapper.framework)"
 
-if [ "$result" -ne "1" ]; then
+if [ "$result" != "1" ]; then
   echo "Coverage is $result, should be 1"
   exit 1
 fi


### PR DESCRIPTION
Previously if result was not 1, the script would fail with a syntax
error, without exiting with a non-zero exit code. Instead we can compare
to 1 specifically.