### PR TITLE
Move default Convertibles to a new file

### DIFF
--- a/Mapper.xcodeproj/project.pbxproj
+++ b/Mapper.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		C2C036FE1C2B1A0B003FB853 /* URL+Convertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2C036F71C2B1A0B003FB853 /* URL+Convertible.swift */; };
 		C2C036FF1C2B1A0B003FB853 /* Transform+Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2C036F81C2B1A0B003FB853 /* Transform+Dictionary.swift */; };
 		C2C037001C2B1A0B003FB853 /* Transform.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2C036F91C2B1A0B003FB853 /* Transform.swift */; };
+		C2F0AE7021A480F300E108C7 /* Defaults+Convertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2F0AE6F21A480F300E108C7 /* Defaults+Convertible.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -67,6 +68,7 @@
 		C2C036F71C2B1A0B003FB853 /* URL+Convertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "URL+Convertible.swift"; sourceTree = "<group>"; };
 		C2C036F81C2B1A0B003FB853 /* Transform+Dictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Transform+Dictionary.swift"; sourceTree = "<group>"; };
 		C2C036F91C2B1A0B003FB853 /* Transform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Transform.swift; sourceTree = "<group>"; };
+		C2F0AE6F21A480F300E108C7 /* Defaults+Convertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Defaults+Convertible.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -141,6 +143,7 @@
 			children = (
 				C2C036F31C2B1A0B003FB853 /* Convertible.swift */,
 				C20586EB1CDEAD9900658A67 /* DefaultConvertible.swift */,
+				C2F0AE6F21A480F300E108C7 /* Defaults+Convertible.swift */,
 				C21F9CCD210FCF5F00761DDC /* Float+Convertible.swift */,
 				C2C036F51C2B1A0B003FB853 /* Mappable.swift */,
 				C2C036F61C2B1A0B003FB853 /* Mapper.swift */,
@@ -247,6 +250,7 @@
 				C2C037001C2B1A0B003FB853 /* Transform.swift in Sources */,
 				C2C036FB1C2B1A0B003FB853 /* MapperError.swift in Sources */,
 				C20586EC1CDEAD9900658A67 /* DefaultConvertible.swift in Sources */,
+				C2F0AE7021A480F300E108C7 /* Defaults+Convertible.swift in Sources */,
 				C2C036FC1C2B1A0B003FB853 /* Mappable.swift in Sources */,
 				C2C036FA1C2B1A0B003FB853 /* Convertible.swift in Sources */,
 			);

--- a/Sources/DefaultConvertible.swift
+++ b/Sources/DefaultConvertible.swift
@@ -18,22 +18,3 @@ extension DefaultConvertible {
         throw MapperError.convertibleError(value: value, type: ConvertedType.self)
     }
 }
-
-// MARK: - Default Conformances
-
-/// These Foundation conformances are acceptable since we already depend on Foundation. No other frameworks
-/// Should be important as part of Mapper for default conformances. Consumers should conform any other common
-/// Types in an extension in their own projects (e.g. `CGFloat`)
-import Foundation
-extension NSDictionary: DefaultConvertible {}
-extension NSArray: DefaultConvertible {}
-
-extension String: DefaultConvertible {}
-extension Int: DefaultConvertible {}
-extension Int32: DefaultConvertible {}
-extension Int64: DefaultConvertible {}
-extension UInt: DefaultConvertible {}
-extension UInt32: DefaultConvertible {}
-extension UInt64: DefaultConvertible {}
-extension Double: DefaultConvertible {}
-extension Bool: DefaultConvertible {}

--- a/Sources/Defaults+Convertible.swift
+++ b/Sources/Defaults+Convertible.swift
@@ -1,0 +1,16 @@
+/// These Foundation conformances are acceptable since we already depend on Foundation. No other frameworks
+/// Should be important as part of Mapper for default conformances. Consumers should conform any other common
+/// Types in an extension in their own projects (e.g. `CGFloat`)
+import Foundation
+extension NSDictionary: DefaultConvertible {}
+extension NSArray: DefaultConvertible {}
+
+extension String: DefaultConvertible {}
+extension Int: DefaultConvertible {}
+extension Int32: DefaultConvertible {}
+extension Int64: DefaultConvertible {}
+extension UInt: DefaultConvertible {}
+extension UInt32: DefaultConvertible {}
+extension UInt64: DefaultConvertible {}
+extension Double: DefaultConvertible {}
+extension Bool: DefaultConvertible {}


### PR DESCRIPTION
This will make it easier to make a subspec that excludes these.