### PR TITLE
Remove public from extensions

### DIFF
--- a/Sources/Mappable.swift
+++ b/Sources/Mappable.swift
@@ -23,7 +23,7 @@ public protocol Mappable {
     init(map: Mapper) throws
 }
 
-public extension Mappable {
+extension Mappable {
     /// Convenience method for creating Mappable objects from NSDictionaries
     ///
     /// - parameter JSON: The JSON to create the object from

--- a/Sources/Transform+Dictionary.swift
+++ b/Sources/Transform+Dictionary.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public extension Transform {
+extension Transform {
     /// A provided transformation function (see Transform and Mapper for uses) in order to create a dictionary
     /// from an array of values. The idea for this is to create a dictionary based on an array of values,
     /// using a custom function to extract the key used in the dictionary


### PR DESCRIPTION
This fixes warnings with the Swift 5 compiler, the contents of these
extensions are explicitly public already, and this will make sure we
don't accidentally add public API that we meant to be internal.