### PR TITLE
Fix linker failure on Xcode 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 ## Enhancements
 
-- None
+- Fix Swift 5.3 linker error
+  [#168](https://github.com/lyft/mapper/pull/168)
+  [#169](https://github.com/lyft/mapper/pull/169)
 
 # 10.0.0
 

--- a/Sources/NSDictionary+Safety.swift
+++ b/Sources/NSDictionary+Safety.swift
@@ -4,7 +4,7 @@ extension NSDictionary {
     @nonobjc
     func safeValue(forKeyPath keyPath: String) -> Any? {
         var object: Any? = self
-        var keys = keyPath.split(separator: ".").map(String.init)
+        var keys = keyPath.split(separator: ".")
 
         while !keys.isEmpty, let currentObject = object {
             let key = keys.remove(at: 0)


### PR DESCRIPTION
This removes a now unnecessary cast which also fixes a linker failure in
the Xcode 12 betas