### PR TITLE
Update UniversalFramework_Base.xcconfig 

### DIFF
--- a/Resources/xcconfigs/UniversalFramework_Base.xcconfig
+++ b/Resources/xcconfigs/UniversalFramework_Base.xcconfig
@@ -9,7 +9,7 @@
 SUPPORTED_PLATFORMS                    = macosx iphonesimulator iphoneos watchos watchsimulator appletvos appletvsimulator
 VALID_ARCHS[sdk=macosx*]               = i386 x86_64
 VALID_ARCHS[sdk=iphoneos*]             = arm64 armv7 armv7s
-VALID_ARCHS[sdk=iphonesimulator*]      = i386 x86_64
+VALID_ARCHS[sdk=iphonesimulator*]      = i386 x86_64 arm64
 VALID_ARCHS[sdk=watchos*]              = armv7k
 VALID_ARCHS[sdk=watchsimulator*]       = i386
 VALID_ARCHS[sdk=appletv*]              = arm64


### PR DESCRIPTION
to support Carthage xcframework build for Apple silicon M1(arm64 iphonesimulator)