### PR TITLE
fix: relative path traversal vulnerability allows loading of arbitrary files

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,7 +57,7 @@ GEM
     netrc (0.11.0)
     ruby-macho (1.3.1)
     thread_safe (0.3.6)
-    tzinfo (1.2.5)
+    tzinfo (1.2.11)
       thread_safe (~> 0.1)
     xcodeproj (1.7.0)
       CFPropertyList (>= 2.3.3, < 4.0)


### PR DESCRIPTION

Affected of this project `lyft/mapper` are vulnerable to Directory Traversal. `TZInfo::Timezone.get` fails to validate time zone identifiers correctly, allowing a new line character within the identifier. With Ruby version 1.9.3 and later, TZInfo::Timezone.get can be made to load unintended files with require, executing them within the Ruby process. that allows file uploads and has a time zone selector that accepts arbitrary time zone identifiers.

```js
        raise InvalidTimezoneIdentifier, 'Invalid identifier' if identifier !~ /^[A-Za-z0-9\+\-_]+(\/[A-Za-z0-9\+\-_]+)*$/
    assert_raises(InvalidTimezoneIdentifier) { Timezone.get('../Definitions/UTC') }
```
CWE-22
CWE-23
`CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H`